### PR TITLE
Eliminate warnings w.r.t. ghc-8.4.3

### DIFF
--- a/rhine/rhine.cabal
+++ b/rhine/rhine.cabal
@@ -107,6 +107,9 @@ library
   hs-source-dirs:      src
 
   ghc-options:         -Wall
+                       -Wno-unused-imports
+                       -Wno-unticked-promoted-constructors
+                       -Wno-type-defaults
 
   -- Base language which the package is written in.
   default-language:    Haskell2010

--- a/rhine/src/FRP/Rhine/ResamplingBuffer/MSF.hs
+++ b/rhine/src/FRP/Rhine/ResamplingBuffer/MSF.hs
@@ -30,7 +30,7 @@ msfBuffer = msfBuffer' []
       -> ResamplingBuffer m cl1 cl2 a b
     msfBuffer' as msf = ResamplingBuffer {..}
       where
-        put ti1 a = return $ msfBuffer' msf $ (ti1, a) : as
+        put ti1 a = return $ msfBuffer' ((ti1, a) : as) msf
         get ti2   = do
           (b, msf') <- unMSF msf (ti2, as)
           return (b, msfBuffer msf')

--- a/rhine/src/FRP/Rhine/ResamplingBuffer/MSF.hs
+++ b/rhine/src/FRP/Rhine/ResamplingBuffer/MSF.hs
@@ -21,14 +21,14 @@ msfBuffer
   --   and outputs a single value.
   --   The list will contain the /newest/ element in the head.
   -> ResamplingBuffer m cl1 cl2 a b
-msfBuffer sf = msfBuffer' sf []
+msfBuffer = msfBuffer' []
   where
     msfBuffer'
       :: Monad m
-      => MSF m (TimeInfo cl2, [(TimeInfo cl1, a)]) b
-      -> [(TimeInfo cl1, a)]
+      => [(TimeInfo cl1, a)]
+      -> MSF m (TimeInfo cl2, [(TimeInfo cl1, a)]) b
       -> ResamplingBuffer m cl1 cl2 a b
-    msfBuffer' msf as = ResamplingBuffer {..}
+    msfBuffer' as msf = ResamplingBuffer {..}
       where
         put ti1 a = return $ msfBuffer' msf $ (ti1, a) : as
         get ti2   = do

--- a/rhine/src/FRP/Rhine/ResamplingBuffer/MSF.hs
+++ b/rhine/src/FRP/Rhine/ResamplingBuffer/MSF.hs
@@ -21,7 +21,7 @@ msfBuffer
   --   and outputs a single value.
   --   The list will contain the /newest/ element in the head.
   -> ResamplingBuffer m cl1 cl2 a b
-msfBuffer msf = msfBuffer' msf []
+msfBuffer sf = msfBuffer' sf []
   where
     msfBuffer'
       :: Monad m


### PR DESCRIPTION
This eliminates all the warnings in `rhine/rhine` for the 3 GHC versions used in Travis.