### PR TITLE
removed Data.Semigroup imports to deprecate ghc <8.4

### DIFF
--- a/rhine/src/FRP/Rhine/ClSF/Upsample.hs
+++ b/rhine/src/FRP/Rhine/ClSF/Upsample.hs
@@ -6,9 +6,6 @@
 
 module FRP.Rhine.ClSF.Upsample where
 
--- base
-import Data.Semigroup
-
 -- dunai
 import Control.Monad.Trans.MSF.Reader
 --import Data.MonadicStreamFunction

--- a/rhine/src/FRP/Rhine/Clock/Realtime/Event.hs
+++ b/rhine/src/FRP/Rhine/Clock/Realtime/Event.hs
@@ -33,7 +33,6 @@ module FRP.Rhine.Clock.Realtime.Event
 -- base
 import Control.Concurrent.Chan
 import Data.Time.Clock
-import Data.Semigroup
 
 -- deepseq
 import Control.DeepSeq

--- a/rhine/src/FRP/Rhine/Clock/Realtime/Stdin.hs
+++ b/rhine/src/FRP/Rhine/Clock/Realtime/Stdin.hs
@@ -11,14 +11,12 @@ module FRP.Rhine.Clock.Realtime.Stdin where
 
 -- base
 import Data.Time.Clock
-import Data.Semigroup
 
 -- transformers
 import Control.Monad.IO.Class
 
 -- rhine
 import FRP.Rhine
-import Data.Semigroup
 
 {- |
 A clock that ticks for every line entered on the console,

--- a/rhine/src/FRP/Rhine/Clock/Select.hs
+++ b/rhine/src/FRP/Rhine/Clock/Select.hs
@@ -22,7 +22,6 @@ import Data.MonadicStreamFunction.Async (concatS)
 
 -- base
 import Data.Maybe (catMaybes, maybeToList)
-import Data.Semigroup
 
 -- | A clock that selects certain subevents of type 'a',
 --   from the tag of a main clock.

--- a/rhine/src/FRP/Rhine/Schedule.hs
+++ b/rhine/src/FRP/Rhine/Schedule.hs
@@ -21,9 +21,6 @@ Specific implementations of schedules are found in submodules.
 
 module FRP.Rhine.Schedule where
 
--- base
-import Data.Semigroup
-
 -- transformers
 import Control.Monad.Trans.Reader
 


### PR DESCRIPTION
As per #100 --> I understood this as removing all Data.Semigroup imports, since you've already updated the rhine.cabal imports?

Hope this is alright :)