### PR TITLE
Add first resampling constructor

### DIFF
--- a/rhine/src/FRP/Rhine/Clock.hs
+++ b/rhine/src/FRP/Rhine/Clock.hs
@@ -7,7 +7,6 @@ This module provides the 'Clock' type class, several utilities,
 and certain general constructions of 'Clock's,
 such as clocks lifted along monad morphisms or time rescalings.
 -}
-{-# LANGUAGE Arrows #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}

--- a/rhine/src/FRP/Rhine/Clock/Periodic.hs
+++ b/rhine/src/FRP/Rhine/Clock/Periodic.hs
@@ -8,12 +8,10 @@ The time differences are supplied at the type level.
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
-{-# LANGUAGE TypeSynonymInstances #-}
 module FRP.Rhine.Clock.Periodic (Periodic (Periodic)) where
 
 -- base
@@ -45,7 +43,7 @@ instance (Monad m, NonemptyNatList v)
   type Time (Periodic v) = Integer
   type Tag  (Periodic v) = ()
   initClock cl = return
-    ( cycleS (theList cl) >>> withSideEffect wait >>> (accumulateWith (+) 0) &&& arr (const ())
+    ( cycleS (theList cl) >>> withSideEffect wait >>> accumulateWith (+) 0 &&& arr (const ())
     , 0
     )
 

--- a/rhine/src/FRP/Rhine/Clock/Realtime/Audio.hs
+++ b/rhine/src/FRP/Rhine/Clock/Realtime/Audio.hs
@@ -6,7 +6,6 @@ for realtime as well as for batch/file processing.
 {-# LANGUAGE Arrows #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeFamilies #-}
 

--- a/rhine/src/FRP/Rhine/Clock/Realtime/Event.hs
+++ b/rhine/src/FRP/Rhine/Clock/Realtime/Event.hs
@@ -22,7 +22,6 @@ A simple example using events and threads can be found in rhine-examples.
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeSynonymInstances #-}
 module FRP.Rhine.Clock.Realtime.Event
   ( module FRP.Rhine.Clock.Realtime.Event
   , module Control.Monad.IO.Class
@@ -74,7 +73,7 @@ and then use 'withChanS'.
 -}
 runEventChanT :: MonadIO m => EventChanT event m a -> m a
 runEventChanT a = do
-  chan <- liftIO $ newChan
+  chan <- liftIO newChan
   runReaderT a chan
 
 {- | Remove ("run") an 'EventChanT' layer from the monad stack
@@ -156,7 +155,7 @@ instance MonadIO m => Clock (EventChanT event m) (EventClock event) where
       ( constM $ do
           chan  <- ask
           event <- liftIO $ readChan chan
-          time  <- liftIO $ getCurrentTime
+          time  <- liftIO getCurrentTime
           return (time, event)
       , initialTime
       )

--- a/rhine/src/FRP/Rhine/Clock/Realtime/Millisecond.hs
+++ b/rhine/src/FRP/Rhine/Clock/Realtime/Millisecond.hs
@@ -2,9 +2,7 @@
 Provides a clock that ticks at every multiple of a fixed number of milliseconds.
 -}
 
-{-# LANGUAGE Arrows #-}
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}

--- a/rhine/src/FRP/Rhine/Reactimation.hs
+++ b/rhine/src/FRP/Rhine/Reactimation.hs
@@ -3,9 +3,7 @@ Run closed 'Rhine's (which are signal functions together with matching clocks)
 as main loops.
 -}
 
-{-# LANGUAGE Arrows #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE RecordWildCards #-}
 module FRP.Rhine.Reactimation where
 
 -- dunai

--- a/rhine/src/FRP/Rhine/Reactimation/ClockErasure.hs
+++ b/rhine/src/FRP/Rhine/Reactimation/ClockErasure.hs
@@ -7,7 +7,6 @@ and is thus not exported from 'FRP.Rhine'.
 {-# LANGUAGE Arrows #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TupleSections #-}
 module FRP.Rhine.Reactimation.ClockErasure where
 
@@ -71,7 +70,7 @@ eraseClockSN initialTime (Sequential sn1 resBuf sn2) =
       maybeB <- eraseClockSN initialTime sn1 -< (time, tagL, maybeA)
       returnA -< Left <$> ((time, , ) <$> outTag proxy1 tagL <*> maybeB)
     Right tagR -> do
-      returnA -< Right <$> (time, ) <$> inTag proxy2 tagR
+      returnA -< Right . (time, ) <$> inTag proxy2 tagR
   maybeC <- mapMaybeS $ eraseClockResBuf (outProxy proxy1) (inProxy proxy2) initialTime resBuf -< resBufIn
   case tag of
     Left  _    -> do

--- a/rhine/src/FRP/Rhine/Reactimation/ClockErasure.hs
+++ b/rhine/src/FRP/Rhine/Reactimation/ClockErasure.hs
@@ -130,6 +130,18 @@ eraseClockSN initialTime (FirstResampling sn buf) =
     dMaybe <- mapMaybeS $ eraseClockResBuf (inProxy proxy) (outProxy proxy) initialTime buf -< resBufInput
     returnA -< (,) <$> bMaybe <*> join dMaybe
 
+-- eraseClockSN initialTime sn@(Send buf) =
+--   let
+--     proxy = toClockProxy sn
+--   in proc (time, tag, aMaybe) -> do
+--     let
+--       resBufInput = case (inTag proxy tag, outTag proxy tag, aMaybe) of
+--         (Just tagIn, _, Just c) -> Just $ Left (time, tagIn, c)
+--         (_, Just tagOut, _) -> Just $ Right (time, tagOut)
+--         _ -> Nothing
+--     bMaybe <- mapMaybeS $ eraseClockResBuf (inProxy proxy) (outProxy proxy) initialTime buf -< resBufInput
+--     returnA -< join bMaybe
+
 -- | Translate a resampling buffer into a monadic stream function.
 --
 --   The input decides whether the buffer is to accept input or has to produce output.

--- a/rhine/src/FRP/Rhine/Reactimation/ClockErasure.hs
+++ b/rhine/src/FRP/Rhine/Reactimation/ClockErasure.hs
@@ -130,18 +130,6 @@ eraseClockSN initialTime (FirstResampling sn buf) =
     dMaybe <- mapMaybeS $ eraseClockResBuf (inProxy proxy) (outProxy proxy) initialTime buf -< resBufInput
     returnA -< (,) <$> bMaybe <*> join dMaybe
 
--- eraseClockSN initialTime sn@(Send buf) =
---   let
---     proxy = toClockProxy sn
---   in proc (time, tag, aMaybe) -> do
---     let
---       resBufInput = case (inTag proxy tag, outTag proxy tag, aMaybe) of
---         (Just tagIn, _, Just c) -> Just $ Left (time, tagIn, c)
---         (_, Just tagOut, _) -> Just $ Right (time, tagOut)
---         _ -> Nothing
---     bMaybe <- mapMaybeS $ eraseClockResBuf (inProxy proxy) (outProxy proxy) initialTime buf -< resBufInput
---     returnA -< join bMaybe
-
 -- | Translate a resampling buffer into a monadic stream function.
 --
 --   The input decides whether the buffer is to accept input or has to produce output.

--- a/rhine/src/FRP/Rhine/SN.hs
+++ b/rhine/src/FRP/Rhine/SN.hs
@@ -78,6 +78,14 @@ data SN m cl a b where
     => SN               m cl               a      b
     -> ResamplingBuffer m (In cl) (Out cl)    c      d
     -> SN               m cl              (a, c) (b, d)
+  -- -- | TODO
+  -- Send
+  --   :: ( Clock m (In cl), Clock m (Out cl)
+  --      , Time cl ~ Time (Out cl)
+  --      , Time cl ~ Time (In cl)
+  --      )
+  --   => ResamplingBuffer m (In cl) (Out cl) a b
+  --   -> SN               m cl               a b
   -- | A 'ClSF' can always be postcomposed onto an 'SN' if the clocks match on the output.
   Postcompose
     :: ( Clock m (Out cl)

--- a/rhine/src/FRP/Rhine/SN.hs
+++ b/rhine/src/FRP/Rhine/SN.hs
@@ -69,6 +69,15 @@ data SN m cl a b where
     => SN m                  cl1      a b
     -> SN m                      cl2  a b
     -> SN m (ParallelClock m cl1 cl2) a b
+  -- | Bypass the signal network by forwarding data in parallel through a 'ResamplingBuffer'.
+  FirstResampling
+    :: ( Clock m (In cl), Clock m (Out cl)
+       , Time cl ~ Time (Out cl)
+       , Time cl ~ Time (In cl)
+       )
+    => SN               m cl               a      b
+    -> ResamplingBuffer m (In cl) (Out cl)    c      d
+    -> SN               m cl              (a, c) (b, d)
   -- | A 'ClSF' can always be postcomposed onto an 'SN' if the clocks match on the output.
   Postcompose
     :: ( Clock m (Out cl)

--- a/rhine/src/FRP/Rhine/SN.hs
+++ b/rhine/src/FRP/Rhine/SN.hs
@@ -78,14 +78,6 @@ data SN m cl a b where
     => SN               m cl               a      b
     -> ResamplingBuffer m (In cl) (Out cl)    c      d
     -> SN               m cl              (a, c) (b, d)
-  -- -- | TODO
-  -- Send
-  --   :: ( Clock m (In cl), Clock m (Out cl)
-  --      , Time cl ~ Time (Out cl)
-  --      , Time cl ~ Time (In cl)
-  --      )
-  --   => ResamplingBuffer m (In cl) (Out cl) a b
-  --   -> SN               m cl               a b
   -- | A 'ClSF' can always be postcomposed onto an 'SN' if the clocks match on the output.
   Postcompose
     :: ( Clock m (Out cl)

--- a/rhine/src/FRP/Rhine/SN/Combinators.hs
+++ b/rhine/src/FRP/Rhine/SN/Combinators.hs
@@ -29,7 +29,6 @@ Precompose clsf sn >>>^ f = Precompose clsf $ sn >>>^ f
 Feedback buf sn >>>^ f = Feedback buf $ sn >>>^ first f
 -- That's a bit surprising... I think we're not at the end of the SN tale yet
 firstResampling@(FirstResampling _ _) >>>^ f = Postcompose firstResampling $ arr f
--- Send rb >>>^ f = _ -- FIXME This is just profunctor
 
 -- | Precompose a signal network with a pure function.
 (^>>>)
@@ -92,9 +91,6 @@ sn1 **** Feedback buf sn2 = Feedback buf $ (\((a, c), c1) -> (a, (c, c1))) ^>>> 
 -- FIXME This changes order of execution :(
 FirstResampling sn1 buf **** sn2 = (\((a1, c1), c) -> ((a1, c), c1)) ^>>> FirstResampling (sn1 **** sn2) buf >>>^ (\((b1, d), d1) -> ((b1, d1), d))
 sn1 **** FirstResampling sn2 buf = (\(a, (a1, c1)) -> ((a, a1), c1)) ^>>> FirstResampling (sn1 **** sn2) buf >>>^ (\((b, b1), d1) -> (b, (b1, d1)))
-
--- Send buf1 **** Send buf2 = Send $ buf1 *-* buf2
--- Send buf **** Synchronous clsf = _
 
 -- Note that the patterns above are the only ones that can occur.
 -- This is ensured by the clock constraints in the SF constructors.

--- a/rhine/src/FRP/Rhine/SN/Combinators.hs
+++ b/rhine/src/FRP/Rhine/SN/Combinators.hs
@@ -27,7 +27,6 @@ Parallel   sn1    sn2 >>>^ f = Parallel  (sn1 >>>^ f) (sn2 >>>^ f)
 Postcompose sn clsf >>>^ f = Postcompose sn $ clsf >>^ f
 Precompose clsf sn >>>^ f = Precompose clsf $ sn >>>^ f
 Feedback buf sn >>>^ f = Feedback buf $ sn >>>^ first f
--- That's a bit surprising... I think we're not at the end of the SN tale yet
 firstResampling@(FirstResampling _ _) >>>^ f = Postcompose firstResampling $ arr f
 
 -- | Precompose a signal network with a pure function.
@@ -88,7 +87,6 @@ sn1 **** Postcompose sn2 clsf = Postcompose (sn1 **** sn2) (second clsf)
 Feedback buf sn1 **** sn2 = Feedback buf $ (\((a, c), c1) -> ((a, c1), c)) ^>>> (sn1 **** sn2) >>>^ (\((b, d1), d) -> ((b, d), d1))
 sn1 **** Feedback buf sn2 = Feedback buf $ (\((a, c), c1) -> (a, (c, c1))) ^>>> (sn1 **** sn2) >>>^ (\(b, (d, d1)) -> ((b, d), d1))
 
--- FIXME This changes order of execution :(
 FirstResampling sn1 buf **** sn2 = (\((a1, c1), c) -> ((a1, c), c1)) ^>>> FirstResampling (sn1 **** sn2) buf >>>^ (\((b1, d), d1) -> ((b1, d1), d))
 sn1 **** FirstResampling sn2 buf = (\(a, (a1, c1)) -> ((a, a1), c1)) ^>>> FirstResampling (sn1 **** sn2) buf >>>^ (\((b, b1), d1) -> (b, (b1, d1)))
 

--- a/rhine/src/FRP/Rhine/SN/Combinators.hs
+++ b/rhine/src/FRP/Rhine/SN/Combinators.hs
@@ -27,6 +27,8 @@ Parallel   sn1    sn2 >>>^ f = Parallel  (sn1 >>>^ f) (sn2 >>>^ f)
 Postcompose sn clsf >>>^ f = Postcompose sn $ clsf >>^ f
 Precompose clsf sn >>>^ f = Precompose clsf $ sn >>>^ f
 Feedback buf sn >>>^ f = Feedback buf $ sn >>>^ first f
+-- That's a bit surprising... I think we're not at the end of the SN tale yet
+firstResampling@(FirstResampling _ _) >>>^ f = Postcompose firstResampling $ arr f
 
 -- | Precompose a signal network with a pure function.
 (^>>>)
@@ -40,6 +42,7 @@ f ^>>> Parallel   sn1    sn2 = Parallel   (f ^>>> sn1) (f ^>>> sn2)
 f ^>>> Postcompose sn clsf = Postcompose (f ^>>> sn) clsf
 f ^>>> Precompose clsf sn = Precompose (f ^>> clsf) sn
 f ^>>> Feedback buf sn = Feedback buf $ first f ^>>> sn
+f ^>>> firstResampling@(FirstResampling _ _) = Precompose (arr f) firstResampling
 
 -- | Postcompose a signal network with a 'ClSF'.
 (>--^)
@@ -84,6 +87,10 @@ sn1 **** Postcompose sn2 clsf = Postcompose (sn1 **** sn2) (second clsf)
 
 Feedback buf sn1 **** sn2 = Feedback buf $ (\((a, c), c1) -> ((a, c1), c)) ^>>> (sn1 **** sn2) >>>^ (\((b, d1), d) -> ((b, d), d1))
 sn1 **** Feedback buf sn2 = Feedback buf $ (\((a, c), c1) -> (a, (c, c1))) ^>>> (sn1 **** sn2) >>>^ (\(b, (d, d1)) -> ((b, d), d1))
+
+-- FIXME This changes order of execution :(
+FirstResampling sn1 buf **** sn2 = (\((a1, c1), c) -> ((a1, c), c1)) ^>>> FirstResampling (sn1 **** sn2) buf >>>^ (\((b1, d), d1) -> ((b1, d1), d))
+sn1 **** FirstResampling sn2 buf = (\(a, (a1, c1)) -> ((a, a1), c1)) ^>>> FirstResampling (sn1 **** sn2) buf >>>^ (\((b, b1), d1) -> (b, (b1, d1)))
 
 -- Note that the patterns above are the only ones that can occur.
 -- This is ensured by the clock constraints in the SF constructors.

--- a/rhine/src/FRP/Rhine/SN/Combinators.hs
+++ b/rhine/src/FRP/Rhine/SN/Combinators.hs
@@ -29,6 +29,7 @@ Precompose clsf sn >>>^ f = Precompose clsf $ sn >>>^ f
 Feedback buf sn >>>^ f = Feedback buf $ sn >>>^ first f
 -- That's a bit surprising... I think we're not at the end of the SN tale yet
 firstResampling@(FirstResampling _ _) >>>^ f = Postcompose firstResampling $ arr f
+-- Send rb >>>^ f = _ -- FIXME This is just profunctor
 
 -- | Precompose a signal network with a pure function.
 (^>>>)
@@ -91,6 +92,9 @@ sn1 **** Feedback buf sn2 = Feedback buf $ (\((a, c), c1) -> (a, (c, c1))) ^>>> 
 -- FIXME This changes order of execution :(
 FirstResampling sn1 buf **** sn2 = (\((a1, c1), c) -> ((a1, c), c1)) ^>>> FirstResampling (sn1 **** sn2) buf >>>^ (\((b1, d), d1) -> ((b1, d1), d))
 sn1 **** FirstResampling sn2 buf = (\(a, (a1, c1)) -> ((a, a1), c1)) ^>>> FirstResampling (sn1 **** sn2) buf >>>^ (\((b, b1), d1) -> (b, (b1, d1)))
+
+-- Send buf1 **** Send buf2 = Send $ buf1 *-* buf2
+-- Send buf **** Synchronous clsf = _
 
 -- Note that the patterns above are the only ones that can occur.
 -- This is ensured by the clock constraints in the SF constructors.

--- a/rhine/src/FRP/Rhine/Schedule.hs
+++ b/rhine/src/FRP/Rhine/Schedule.hs
@@ -81,7 +81,7 @@ rescaledSchedule
   :: Monad m
   => Schedule m cl1 cl2
   -> Schedule m (RescaledClock cl1 time) (RescaledClock cl2 time)
-rescaledSchedule schedule = Schedule $ initSchedule'
+rescaledSchedule schedule = Schedule initSchedule'
   where
     initSchedule' cl1 cl2 = initSchedule (rescaledScheduleS schedule) (rescaledClockToS cl1) (rescaledClockToS cl2)
 


### PR DESCRIPTION
This is in analogy to [`first`](https://hackage.haskell.org/package/base-4.17.0.0/docs/Control-Arrow.html#v:first), an important `Arrow` method.