### PR TITLE
Bayes benchmarks

### DIFF
--- a/rhine-bayes/app/Main.hs
+++ b/rhine-bayes/app/Main.hs
@@ -347,5 +347,10 @@ mainMultiRate =
 instance MonadDistribution m => MonadDistribution (GlossConcT m) where
   random = lift random
 
+instance MonadFactor m => MonadFactor (GlossConcT m) where
+  score = lift . score
+
+instance MonadMeasure m => MonadMeasure (GlossConcT m) where
+
 sampleIOGloss :: App a -> GlossConcT IO a
 sampleIOGloss = hoist sampleIO

--- a/rhine-bayes/app/Main.hs
+++ b/rhine-bayes/app/Main.hs
@@ -78,10 +78,6 @@ prior = prior1d 10 0 &&& prior1d 0 10
 
 -- ** Observation
 
--- | Internal utility because `gloss` operates on floats
-double2FloatTuple :: (Double, Double) -> (Float, Float)
-double2FloatTuple = double2Float *** double2Float
-
 -- | An integral where the integrated value dies of exponentially
 decayIntegral :: (VectorSpace v (Diff td), Monad m, Floating (Diff td)) => Diff td -> BehaviourF m td v v
 decayIntegral timeConstant = (timeConstant *^) <$> average timeConstant
@@ -157,6 +153,10 @@ nParticles :: Int
 nParticles = 100
 
 -- * Visualization
+
+-- | Internal utility because `gloss` operates on floats
+double2FloatTuple :: (Double, Double) -> (Float, Float)
+double2FloatTuple = double2Float *** double2Float
 
 {- | The monad in which our program will run.
    'SamplerIO' is for the probabilistic effects from @monad-bayes@,

--- a/rhine-bayes/models/Model/Oscillator.hs
+++ b/rhine-bayes/models/Model/Oscillator.hs
@@ -1,0 +1,3 @@
+module Model.Oscillator where
+
+    

--- a/rhine-bayes/rhine-bayes.cabal
+++ b/rhine-bayes/rhine-bayes.cabal
@@ -58,7 +58,6 @@ library
 executable rhine-bayes-gloss
   main-is:             Main.hs
   hs-source-dirs:      app
-  ghc-options:         -threaded
   build-depends:       base         >= 4.11 && < 4.18
                      , rhine
                      , rhine-bayes

--- a/rhine-bayes/rhine-bayes.cabal
+++ b/rhine-bayes/rhine-bayes.cabal
@@ -82,6 +82,23 @@ executable rhine-bayes-gloss
   if flag(dev)
     ghc-options: -Werror
 
+test-suite test
+  main-is: Main.hs
+  type: exitcode-stdio-1.0
+  other-modules:
+    Oscillator
+  hs-source-dirs:
+    test
+    models
+  build-depends:
+      base         >= 4.11 && < 4.18
+    , rhine
+    , rhine-bayes
+    , monad-bayes
+  if flag(dev)
+    ghc-options: -Werror
+
+
 flag dev
   description: Enable warnings as errors. Active on ci.
   default: False

--- a/rhine-bayes/test/Main.hs
+++ b/rhine-bayes/test/Main.hs
@@ -1,0 +1,3 @@
+module Main where
+
+main = return ()

--- a/rhine-bayes/test/Oscillator.hs
+++ b/rhine-bayes/test/Oscillator.hs
@@ -1,0 +1,1 @@
+module Oscillator where


### PR DESCRIPTION
* [ ] Create a test suite that runs the oscillator example with a simulated clock
* [ ] Measure inference quality in terms of mean & variance
* [ ] Test that for fixed RNG, these quality indicators do not change significantly from the current value, over several different runs
* [ ] Perhaps using https://github.com/Bodigrim/tasty-bench-fit, ensure that complexity is constant over time