### PR TITLE
Effective Sample Size & tempering/annealing

### DIFF
--- a/rhine-bayes/app/Main.hs
+++ b/rhine-bayes/app/Main.hs
@@ -330,7 +330,7 @@ inferenceRMSMC = hoistClSF sampleIOGloss inferenceBehaviour @@ liftClock Busy
  where
   inferenceBehaviour :: (MonadDistribution m, Diff td ~ Double, MonadIO m) => BehaviourF m td (Temperature, (Sensor, Pos)) Result
   inferenceBehaviour = proc (temperature, (measured, latent)) -> do
-    particles <- resampleMoveSequentialMonteCarloCl nParticles 10 resampleSystematic posteriorTemperatureProcess -< measured
+    particles <- resampleMoveSequentialMonteCarloCl 2 1 resampleSystematic posteriorTemperatureProcess -< measured
     returnA -< Result{temperature, measured, latent, particles}
 
 -- | Visualize the current 'Result' at a rate controlled by the @gloss@ backend, usually 30 FPS.

--- a/rhine-bayes/app/Main.hs
+++ b/rhine-bayes/app/Main.hs
@@ -407,6 +407,12 @@ mainMultiRateRMSMC =
     launchGlossThread glossSettings $
       flow mainRhineMultiRateRMSMC
 
+mainMultiRateRMSMCDyn :: IO ()
+mainMultiRateRMSMCDyn =
+  void $
+    launchGlossThread glossSettings $
+      flow mainRhineMultiRateRMSMCDyn
+
 -- * Utilities
 
 instance MonadDistribution m => MonadDistribution (GlossConcT m) where

--- a/rhine-bayes/app/Main.hs
+++ b/rhine-bayes/app/Main.hs
@@ -330,7 +330,7 @@ inferenceRMSMC = hoistClSF sampleIOGloss inferenceBehaviour @@ liftClock Busy
  where
   inferenceBehaviour :: (MonadDistribution m, Diff td ~ Double, MonadIO m) => BehaviourF m td (Temperature, (Sensor, Pos)) Result
   inferenceBehaviour = proc (temperature, (measured, latent)) -> do
-    particles <- resampleMoveSequentialMonteCarloCl 2 1 resampleSystematic posteriorTemperatureProcess -< measured
+    particles <- resampleMoveSequentialMonteCarloCl 10 1 resampleSystematic posteriorTemperatureProcess -< measured
     returnA -< Result{temperature, measured, latent, particles}
 
 -- | Visualize the current 'Result' at a rate controlled by the @gloss@ backend, usually 30 FPS.

--- a/rhine-bayes/src/Data/MonadicStreamFunction/Bayes.hs
+++ b/rhine-bayes/src/Data/MonadicStreamFunction/Bayes.hs
@@ -12,13 +12,14 @@ import Numeric.Log hiding (sum)
 
 -- monad-bayes
 import Control.Monad.Bayes.Population
-import Control.Monad.Bayes.Traced.Class
+import Control.Monad.Bayes.Traced
 
 -- dunai
 import Data.MonadicStreamFunction
 import Data.MonadicStreamFunction.InternalCore (MSF (..))
 import Control.Monad.Trans.Class
 import Control.Monad.Bayes.Class (MonadDistribution)
+import qualified Control.Monad.Bayes.Traced.Static as Static
 
 -- FIXME rename to sequentialMonteCarlo or smc?
 -- | Run the Sequential Monte Carlo algorithm continuously on an 'MSF'
@@ -53,35 +54,53 @@ runPopulationsS resampler = go
           (swap . fmap fst &&& swap . fmap snd) . swap <$> bAndMSFs
 
 resampleMoveSequentialMonteCarlo ::
-  forall t m a b.
-  (MonadDistribution m, HasTraced t, MonadTrans t) =>
+  forall m a b.
+  MonadDistribution m =>
+  -- (MonadDistribution m, HasTraced t, MonadTrans t) =>
   -- | Number of particles
   Int ->
   -- | Number of MC steps
   Int ->
   -- | Resampler
   (forall x. Population m x -> Population m x) ->
-  MSF (t (Population m)) a b ->
+  MSF (Static.Traced (Population m)) a b ->
+  -- MSF (t (Population m)) a b ->
   -- FIXME Why not MSF m a (Population b)
   MSF m a [(b, Log Double)]
 resampleMoveSequentialMonteCarlo nParticles nMC resampler = go . (spawn nParticles $>)
   where
     go ::
       Monad m =>
-      Population m (MSF (t (Population m)) a b) ->
+      Population m (MSF (Static.Traced (Population m)) a b) ->
+      -- Population m (MSF (t (Population m)) a b) ->
       MSF m a [(b, Log Double)]
     go msfs = MSF $ \a -> do
       -- TODO This is quite different than the dunai version now. Maybe it's right nevertheless.
       -- FIXME This normalizes, which introduces bias, whatever that means
-      bAndMSFs <- runPopulation $ normalize $ marginal $ freeze $ composeCopies nMC mhStep $ hoistTrace resampler $ flip unMSF a =<< lift msfs
+      bAndMSFs <- runPopulation
+        $ normalize
+        $ Debug.Trace.trace "4"
+        $ marginal
+        $ Debug.Trace.trace "3"
+        $ composeCopies nMC (Debug.Trace.trace "mhStep" mhStep)
+        $ Debug.Trace.trace "2"
+        $ Control.Monad.Bayes.Traced.hoist (Debug.Trace.trace "resampler" resampler)
+        $ Debug.Trace.trace "1"
+        $ flip unMSF (Debug.Trace.trace "a" a) =<< lift (tracePop "msfs" msfs)
       return $
         second (go . fromWeightedList . return) $
           unzip $
-            (swap . fmap fst &&& swap . fmap snd) . swap <$> bAndMSFs
+            (swap . fmap fst &&& swap . fmap snd) . swap <$> Debug.Trace.trace "bAndMSFs" bAndMSFs
 
+-- | Apply a function a given number of times.
+composeCopies :: Int -> (a -> a) -> (a -> a)
+composeCopies k f = foldr (.) id (replicate k f)
+
+tracePop :: Monad m => String -> Population m a -> Population m a
+tracePop msg = fromWeightedList . fmap (\pop -> Debug.Trace.traceShow (msg, length pop) pop) . runPopulation
 
 -- resampleMoveSequentialMonteCarlo nParticles nMC resampler = morphS marginal $ runPopulationS nParticles $ freeze . composeCopies nMC mhStep . hoistTrace resampler
 
 -- FIXME see PR re-adding this to monad-bayes
 normalize :: Monad m => Population m a -> Population m a
-normalize = fromWeightedList . fmap (\particles -> second (/ (sum $ snd <$> particles)) <$> particles) . runPopulation
+normalize = fromWeightedList . fmap (\particles -> Debug.Trace.traceShow ("length particles", length particles) $ second (/ (sum $ snd <$> particles)) <$> particles) . runPopulation

--- a/rhine-bayes/src/Data/MonadicStreamFunction/Bayes.hs
+++ b/rhine-bayes/src/Data/MonadicStreamFunction/Bayes.hs
@@ -4,6 +4,7 @@ module Data.MonadicStreamFunction.Bayes where
 import Control.Arrow
 import Data.Functor (($>))
 import Data.Tuple (swap)
+import Debug.Trace
 
 -- transformers
 

--- a/rhine-bayes/src/Data/MonadicStreamFunction/Bayes.hs
+++ b/rhine-bayes/src/Data/MonadicStreamFunction/Bayes.hs
@@ -81,10 +81,8 @@ resampleMoveSequentialMonteCarlo nParticles nMC resampler = go . Control.Monad.B
       -- TODO This is quite different than the dunai version now. Maybe it's right nevertheless.
       -- FIXME This normalizes, which introduces bias, whatever that means
       let bAndMSFs = composeCopies nMC mhStep
-            -- $ Debug.Trace.trace "2"
-            $ Control.Monad.Bayes.Traced.hoist (tracePop "after resampler" . Debug.Trace.trace "resampler" resampler . tracePop "before resampler")
-            -- $ Debug.Trace.trace "1"
-            $ flip unMSF (Debug.Trace.trace "a" a) =<< Control.Monad.Bayes.Traced.hoist (tracePop "msfs") msfs
+            $ Control.Monad.Bayes.Traced.hoist resampler
+            $ flip unMSF a =<< msfs
       bs <- runPopulation $ marginal $ fst <$> bAndMSFs
       return (bs, go $ snd <$> bAndMSFs)
 

--- a/rhine-bayes/src/Data/MonadicStreamFunction/Bayes.hs
+++ b/rhine-bayes/src/Data/MonadicStreamFunction/Bayes.hs
@@ -20,6 +20,8 @@ import Data.MonadicStreamFunction.InternalCore (MSF (..))
 import Control.Monad.Trans.Class
 import Control.Monad.Bayes.Class (MonadDistribution)
 import qualified Control.Monad.Bayes.Traced.Static as Static
+import Control.Monad.Bayes.Sequential.Coroutine (hoistFirst)
+import Control.Monad.Trans.MSF (performOnFirstSample)
 
 -- FIXME rename to sequentialMonteCarlo or smc?
 -- | Run the Sequential Monte Carlo algorithm continuously on an 'MSF'
@@ -67,40 +69,34 @@ resampleMoveSequentialMonteCarlo ::
   -- MSF (t (Population m)) a b ->
   -- FIXME Why not MSF m a (Population b)
   MSF m a [(b, Log Double)]
-resampleMoveSequentialMonteCarlo nParticles nMC resampler = go . (spawn nParticles $>)
+resampleMoveSequentialMonteCarlo nParticles nMC resampler = go . Control.Monad.Bayes.Traced.hoist (spawn nParticles >>) . pure
   where
     go ::
       Monad m =>
-      Population m (MSF (Static.Traced (Population m)) a b) ->
+      Static.Traced (Population m) (MSF (Static.Traced (Population m)) a b) ->
       -- Population m (MSF (t (Population m)) a b) ->
       MSF m a [(b, Log Double)]
     go msfs = MSF $ \a -> do
       -- TODO This is quite different than the dunai version now. Maybe it's right nevertheless.
       -- FIXME This normalizes, which introduces bias, whatever that means
-      bAndMSFs <- runPopulation
-        $ normalize
-        $ Debug.Trace.trace "4"
-        $ marginal
-        $ Debug.Trace.trace "3"
-        $ composeCopies nMC (Debug.Trace.trace "mhStep" mhStep)
-        $ Debug.Trace.trace "2"
-        $ Control.Monad.Bayes.Traced.hoist (Debug.Trace.trace "resampler" resampler)
-        $ Debug.Trace.trace "1"
-        $ flip unMSF (Debug.Trace.trace "a" a) =<< lift (tracePop "msfs" msfs)
-      return $
-        second (go . fromWeightedList . return) $
-          unzip $
-            (swap . fmap fst &&& swap . fmap snd) . swap <$> Debug.Trace.trace "bAndMSFs" bAndMSFs
+      let bAndMSFs = composeCopies nMC mhStep
+            -- $ Debug.Trace.trace "2"
+            $ Control.Monad.Bayes.Traced.hoist (tracePop "after resampler" . Debug.Trace.trace "resampler" resampler . tracePop "before resampler")
+            -- $ Debug.Trace.trace "1"
+            $ flip unMSF (Debug.Trace.trace "a" a) =<< Control.Monad.Bayes.Traced.hoist (tracePop "msfs") msfs
+      bs <- runPopulation $ marginal $ fst <$> bAndMSFs
+      return (bs, go $ snd <$> bAndMSFs)
 
 -- | Apply a function a given number of times.
 composeCopies :: Int -> (a -> a) -> (a -> a)
 composeCopies k f = foldr (.) id (replicate k f)
 
 tracePop :: Monad m => String -> Population m a -> Population m a
-tracePop msg = fromWeightedList . fmap (\pop -> Debug.Trace.traceShow (msg, length pop) pop) . runPopulation
+-- tracePop msg = fromWeightedList . fmap (\pop -> Debug.Trace.traceShow (msg, length pop) pop) . runPopulation
+tracePop _ = id
 
 -- resampleMoveSequentialMonteCarlo nParticles nMC resampler = morphS marginal $ runPopulationS nParticles $ freeze . composeCopies nMC mhStep . hoistTrace resampler
 
 -- FIXME see PR re-adding this to monad-bayes
 normalize :: Monad m => Population m a -> Population m a
-normalize = fromWeightedList . fmap (\particles -> Debug.Trace.traceShow ("length particles", length particles) $ second (/ (sum $ snd <$> particles)) <$> particles) . runPopulation
+normalize = fromWeightedList . fmap (\particles -> second (/ (sum $ snd <$> particles)) <$> particles) . runPopulation

--- a/rhine-bayes/src/FRP/Rhine/Bayes.hs
+++ b/rhine-bayes/src/FRP/Rhine/Bayes.hs
@@ -15,8 +15,7 @@ import qualified Data.MonadicStreamFunction.Bayes as DunaiBayes
 
 -- rhine
 import FRP.Rhine
-import Control.Monad.Bayes.Traced.Class (HasTraced)
-import Control.Monad.Trans.Class (MonadTrans)
+import qualified Control.Monad.Bayes.Traced.Static as Static
 
 -- * Inference methods
 
@@ -35,7 +34,8 @@ runPopulationCl :: forall m cl a b . Monad m =>
 runPopulationCl nParticles resampler = DunaiReader.readerS . DunaiBayes.runPopulationS nParticles resampler . DunaiReader.runReaderS
 
 -- | Run the Resample Move Sequential Monte Carlo algorithm continuously on a 'ClSF'.
-resampleMoveSequentialMonteCarloCl :: forall t m cl a b . (MonadDistribution m, HasTraced t, MonadTrans t) =>
+resampleMoveSequentialMonteCarloCl :: forall m cl a b . (MonadDistribution m) =>
+-- resampleMoveSequentialMonteCarloCl :: forall t m cl a b . (MonadDistribution m, HasTraced t, MonadTrans t) =>
   -- | Number of particles
   Int ->
   -- | Number of MC steps
@@ -46,7 +46,7 @@ resampleMoveSequentialMonteCarloCl :: forall t m cl a b . (MonadDistribution m, 
   --   @a@ represents observations upon which the model should condition, using e.g. 'score'.
   --   It can also additionally contain hyperparameters.
   --   @b@ is the type of estimated current state.
-  -> ClSF (t (Population m)) cl a b
+  -> ClSF (Static.Traced (Population m)) cl a b
   -> ClSF m cl a [(b, Log Double)]
 resampleMoveSequentialMonteCarloCl nParticles nMC resampler = DunaiReader.readerS . DunaiBayes.resampleMoveSequentialMonteCarlo nParticles nMC resampler . DunaiReader.runReaderS
 

--- a/rhine-bayes/src/FRP/Rhine/Bayes.hs
+++ b/rhine-bayes/src/FRP/Rhine/Bayes.hs
@@ -16,6 +16,7 @@ import qualified Data.MonadicStreamFunction.Bayes as DunaiBayes
 -- rhine
 import FRP.Rhine
 import qualified Control.Monad.Bayes.Traced.Static as Static
+import qualified Control.Monad.Bayes.Traced.Dynamic as Dynamic
 
 -- * Inference methods
 
@@ -49,6 +50,22 @@ resampleMoveSequentialMonteCarloCl :: forall m cl a b . (MonadDistribution m) =>
   -> ClSF (Static.Traced (Population m)) cl a b
   -> ClSF m cl a [(b, Log Double)]
 resampleMoveSequentialMonteCarloCl nParticles nMC resampler = DunaiReader.readerS . DunaiBayes.resampleMoveSequentialMonteCarlo nParticles nMC resampler . DunaiReader.runReaderS
+
+resampleMoveSequentialMonteCarloDynCl :: forall m cl a b . (MonadDistribution m) =>
+-- resampleMoveSequentialMonteCarloCl :: forall t m cl a b . (MonadDistribution m, HasTraced t, MonadTrans t) =>
+  -- | Number of particles
+  Int ->
+  -- | Number of MC steps
+  Int ->
+  -- | Resampler (see 'Control.Monad.Bayes.Population' for some standard choices)
+  (forall x . Population m x -> Population m x)
+  -- | A signal function modelling the stochastic process on which to perform inference.
+  --   @a@ represents observations upon which the model should condition, using e.g. 'score'.
+  --   It can also additionally contain hyperparameters.
+  --   @b@ is the type of estimated current state.
+  -> ClSF (Dynamic.Traced (Population m)) cl a b
+  -> ClSF m cl a [(b, Log Double)]
+resampleMoveSequentialMonteCarloDynCl nParticles nMC resampler = DunaiReader.readerS . DunaiBayes.resampleMoveSequentialMonteCarloDynamic nParticles nMC resampler . DunaiReader.runReaderS
 
 -- * Short standard library of stochastic processes
 

--- a/rhine-bayes/src/FRP/Rhine/Bayes.hs
+++ b/rhine-bayes/src/FRP/Rhine/Bayes.hs
@@ -1,4 +1,5 @@
-module FRP.Rhine.Bayes where
+module FRP.Rhine.Bayes
+  (module FRP.Rhine.Bayes, module X) where
 
 -- log-domain
 import Numeric.Log hiding (sum)
@@ -12,6 +13,8 @@ import qualified Control.Monad.Trans.MSF.Reader as DunaiReader
 
 -- dunai-bayes
 import qualified Data.MonadicStreamFunction.Bayes as DunaiBayes
+
+import Data.MonadicStreamFunction.Bayes as X (onlyBelowEffectiveSampleSize)
 
 -- rhine
 import FRP.Rhine
@@ -118,3 +121,8 @@ wienerVaryingLogDomain ::
   (MonadDistribution m, Diff td ~ Double) =>
   BehaviourF m td (Diff td) (Log Double)
 wienerVaryingLogDomain = wienerVarying >>> arr Exp
+
+withESS :: Monad m => Double -> ClSF (Population m) cl (a, Double) b -> ClSF (Population m) cl a b
+withESS initESS = DunaiReader.readerS . DunaiBayes.withESS initESS . (arr assoc >>>) . DunaiReader.runReaderS
+  where
+    assoc ((ti, a), td) = (ti, (a, td))


### PR DESCRIPTION
Right now, the best approach to estimating constant parameters seems to be a stochastic diffusion process that keeps & mutates guesses for these parameters in its state, and lowers its temperature with time. This might be called "tempering" or "annealing" in the literature. There are two open research questions:

* [ ] How should the diffusion rate change? It should probably decrease with time, but also increase when the effective sample size is low. How exactly is maybe a matter of taste
* [ ] How does diffusion work for a generic parameter? One might want to make a random walk/MCMC-step on a prior (or posterior) distribution, then this seems to be RMSMC. But the implementation of `mhStep` in `monad-bayes` seems questionable. The other idea would be deriving a diffusion kernel from the parameter type.