### PR TITLE
Add support for dunai 0.11

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1650374568,
-        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
         "type": "github"
       },
       "original": {
@@ -17,12 +17,15 @@
       }
     },
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1652776076,
-        "narHash": "sha256-gzTw/v1vj4dOVbpBSJX4J0DwUR6LIyXo7/SuuTJp1kM=",
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "04c1b180862888302ddfb2e3ad9eaa63afc60cf8",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
         "type": "github"
       },
       "original": {
@@ -38,11 +41,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1653257836,
-        "narHash": "sha256-eCegA8VPrOODmi+NTpFt3WEMDbifyXdrGzcTe078w2c=",
+        "lastModified": 1672412555,
+        "narHash": "sha256-Kaa8F7nQFR3KuS6Y9WRUxeJeZlp6CCubyrRfmiEsW4k=",
         "owner": "ivanovs-4",
         "repo": "haskell-flake-utils",
-        "rev": "e18a8fcd6c32226c4b64617c5ffda2599cda9223",
+        "rev": "896219e5bde6efac72198550454e9dd9b5ed9ac9",
         "type": "github"
       },
       "original": {
@@ -53,11 +56,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1676534113,
-        "narHash": "sha256-bKHSdUUFSsVdxb5hcuBb2NnSpOzQrAR0srLawOPVWmE=",
+        "lastModified": 1695962284,
+        "narHash": "sha256-vygWW+zz/5NHWpH7nIfNFlKiJChp6kVRXkzAcPK08hY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4987c7aacdeeed0b08fcd12ab1c5813b683be7d6",
+        "rev": "cdd726e1deb44c031ee8975528d6b283ed8cf021",
         "type": "github"
       },
       "original": {
@@ -73,6 +76,21 @@
         "flake-utils": "flake-utils",
         "haskell-flake-utils": "haskell-flake-utils",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/rhine-bayes/rhine-bayes.cabal
+++ b/rhine-bayes/rhine-bayes.cabal
@@ -33,7 +33,7 @@ library
   build-depends:       base         >= 4.11 && < 4.18
                      , transformers >= 0.5
                      , rhine        == 1.0
-                     , dunai        ^>= 0.9
+                     , dunai        >= 0.9 && < 0.12
                      , log-domain   >= 0.12
                      , monad-bayes  ^>= 1.1
   hs-source-dirs:      src

--- a/rhine-gloss/rhine-gloss.cabal
+++ b/rhine-gloss/rhine-gloss.cabal
@@ -39,7 +39,7 @@ library
   build-depends:       base         >= 4.14 && < 4.18
                      , transformers >= 0.5
                      , rhine        == 1.0
-                     , dunai        ^>= 0.9
+                     , dunai        >= 0.9 && < 0.12
                      , gloss        >= 1.12
                      , mmorph       >= 1.1
                      , monad-schedule >= 0.1

--- a/rhine-terminal/rhine-terminal.cabal
+++ b/rhine-terminal/rhine-terminal.cabal
@@ -33,7 +33,7 @@ library
                      , exceptions   >= 0.10.4
                      , transformers >= 0.5
                      , rhine        == 1.0
-                     , dunai        ^>= 0.9
+                     , dunai        >= 0.9 && < 0.12
                      , terminal     >= 0.2.0.0
                      , time         >= 1.9.3
                      , monad-schedule >= 0.1.2

--- a/rhine/rhine.cabal
+++ b/rhine/rhine.cabal
@@ -129,7 +129,7 @@ library
 
   -- Other library packages from which modules are imported.
   build-depends:
-                     , dunai        ^>= 0.9
+                     , dunai        >= 0.9 && < 0.12
                      , transformers >= 0.5
                      , time         >= 1.8
                      , free         >= 5.1
@@ -137,8 +137,7 @@ library
                      , deepseq      >= 1.4
                      , random       >= 1.1
                      , MonadRandom  >= 0.5
-                     -- Remove version pin when https://github.com/ivanperez-keera/dunai/issues/298 is resolved:
-                     , simple-affine-space == 0.1.1
+                     , simple-affine-space ^>= 0.2.1
                      , time-domain
                      , monad-schedule >= 0.1.2
 

--- a/rhine/src/FRP/Rhine/ClSF/Util.hs
+++ b/rhine/src/FRP/Rhine/ClSF/Util.hs
@@ -27,6 +27,7 @@ import Control.Monad.Trans.Reader (ask, asks)
 
 -- dunai
 import Control.Monad.Trans.MSF.Reader (readerS)
+import Data.MonadicStreamFunction.Instances.Num ()
 import Data.MonadicStreamFunction.Instances.VectorSpace ()
 
 -- simple-affine-space
@@ -195,6 +196,7 @@ derivative = derivativeFrom zeroVector
 -}
 threePointDerivativeFrom ::
   ( Monad m
+  , Num s
   , VectorSpace v s
   , s ~ Diff td
   ) =>
@@ -211,6 +213,7 @@ threePointDerivativeFrom v0 = proc v -> do
 -}
 threePointDerivative ::
   ( Monad m
+  , Num s
   , VectorSpace v s
   , s ~ Diff td
   ) =>
@@ -229,6 +232,7 @@ threePointDerivative = threePointDerivativeFrom zeroVector
 -}
 weightedAverageFrom ::
   ( Monad m
+  , Fractional s
   , VectorSpace v s
   , s ~ Diff td
   ) =>
@@ -281,6 +285,7 @@ average = averageFrom zeroVector
 -}
 averageLinFrom ::
   ( Monad m
+  , Fractional s
   , VectorSpace v s
   , s ~ Diff td
   ) =>
@@ -298,6 +303,7 @@ averageLinFrom v0 t = proc v -> do
 -- | Linearised version of 'average'.
 averageLin ::
   ( Monad m
+  , Fractional s
   , VectorSpace v s
   , s ~ Diff td
   ) =>
@@ -322,8 +328,9 @@ lowPass = average
 -- | Filters out frequencies below @1 / (2 * pi * t)@.
 highPass ::
   ( Monad m
-  , VectorSpace v s
+  , Eq s
   , Floating s
+  , VectorSpace v s
   , s ~ Diff td
   ) =>
   -- | The time constant @t@
@@ -334,6 +341,7 @@ highPass t = clId ^-^ lowPass t
 -- | Filters out frequencies other than @1 / (2 * pi * t)@.
 bandPass ::
   ( Monad m
+  , Eq s
   , VectorSpace v s
   , Floating s
   , s ~ Diff td
@@ -346,6 +354,7 @@ bandPass t = lowPass t >>> highPass t
 -- | Filters out the frequency @1 / (2 * pi * t)@.
 bandStop ::
   ( Monad m
+  , Eq s
   , VectorSpace v s
   , Floating s
   , s ~ Diff td

--- a/rhine/src/FRP/Rhine/ResamplingBuffer/Interpolation.hs
+++ b/rhine/src/FRP/Rhine/ResamplingBuffer/Interpolation.hs
@@ -23,6 +23,7 @@ import FRP.Rhine.ResamplingBuffer.Util
 -- | A simple linear interpolation based on the last calculated position and velocity.
 linear ::
   ( Monad m
+  , Num s
   , Clock m cl1
   , Clock m cl2
   , VectorSpace v s
@@ -90,6 +91,7 @@ sinc windowSize =
 -}
 cubic ::
   ( Monad m
+  , Fractional s
   , VectorSpace v s
   , Floating v
   , Eq v


### PR DESCRIPTION
I'm a bit struggling with instances:

```
src/FRP/Rhine/ClSF/Util.hs:338:19: error:
    • Could not deduce (Floating
                          (MSF (Control.Monad.Trans.Reader.ReaderT (TimeInfo cl) m) v s))
        arising from a use of ‘^-^’
      from the context: (Monad m, Eq s, Floating s, VectorSpace v s,
                         s ~ Diff td, td ~ Time cl)
        bound by the type signature for:
                   highPass :: forall (m :: Type -> Type) s v td.
                               (Monad m, Eq s, Floating s, VectorSpace v s, s ~ Diff td) =>
                               Diff td -> BehaviourF m td v v
        at src/FRP/Rhine/ClSF/Util.hs:(328,1)-(337,21)
    • In the expression: clId ^-^ lowPass t
      In an equation for ‘highPass’: highPass t = clId ^-^ lowPass t
    |
338 | highPass t = clId ^-^ lowPass t
    |                   ^^^
```

which is weird since:

```
instance (Monad m, Eq s, Num s, VectorSpace v s, Floating (MSF m a s)) => VectorSpace (MSF m a v) (MSF m a s)
instance (Monad m, Floating b) => Floating (MSF m a b)
```

If anyone can have a look