### PR TITLE
Add particle collapse example

### DIFF
--- a/rhine-bayes/app/Main.hs
+++ b/rhine-bayes/app/Main.hs
@@ -156,6 +156,16 @@ data Result = Result
   }
   deriving (Show)
 
+-- | A 'Result' where nothing has been inferred yet
+emptyResult =
+  Result
+    { temperature = initialTemperature
+    , measured = zeroVector
+    , latent = zeroVector
+    , particlesPosition = []
+    , particlesTemperature = []
+    }
+
 -- | The number of particles used in the filter. Change according to available computing power.
 nParticles :: Int
 nParticles = 100
@@ -364,7 +374,7 @@ mainRhineMultiRate =
         modelRhine
         >-- keepLast (initialTemperature, (zeroVector, zeroVector)) -->
           inference
-            >-- keepLast Result {temperature = initialTemperature, measured = zeroVector, latent = zeroVector, particlesPosition = [], particlesTemperature = []} -->
+            >-- keepLast emptyResult -->
               visualisationRhine
 {- FOURMOLU_ENABLE -}
 

--- a/rhine-bayes/rhine-bayes.cabal
+++ b/rhine-bayes/rhine-bayes.cabal
@@ -63,6 +63,7 @@ executable rhine-bayes-gloss
                      , rhine
                      , rhine-bayes
                      , rhine-gloss
+                     , dunai
                      , monad-bayes
                      , transformers
                      , log-domain


### PR DESCRIPTION
Adds an additional example to the `rhine-bayes-gloss` app that demonstrates why a too simplistic approach to parameter estimate fails.