### PR TITLE
rhine-bayes: Pin monad-bayes to 1.1

### DIFF
--- a/rhine-bayes/rhine-bayes.cabal
+++ b/rhine-bayes/rhine-bayes.cabal
@@ -35,7 +35,7 @@ library
                      , rhine        == 1.0
                      , dunai        ^>= 0.9
                      , log-domain   >= 0.12
-                     , monad-bayes  >= 1.1.0
+                     , monad-bayes  ^>= 1.1
   hs-source-dirs:      src
   default-language:    Haskell2010
   default-extensions:


### PR DESCRIPTION
1.2 has breaking API changes, so pinning until it is available in nixpkgs