### PR TITLE
Dev catch

### DIFF
--- a/rhine/rhine.cabal
+++ b/rhine/rhine.cabal
@@ -26,6 +26,7 @@ category: FRP
 build-type: Simple
 extra-source-files: ChangeLog.md
 extra-doc-files: README.md
+data-files: test/assets/*.txt
 tested-with:
   ghc ==9.0.2
   ghc ==9.2.8
@@ -43,6 +44,8 @@ source-repository this
 common opts
   build-depends:
     base >=4.14 && <4.18,
+    text >=1.2 && <2.1,
+    transformers >=0.5,
     vector-sized >=1.4,
 
   if flag(dev)
@@ -53,6 +56,7 @@ common opts
     -Wno-unticked-promoted-constructors
 
   default-extensions:
+    Arrows
     DataKinds
     FlexibleContexts
     FlexibleInstances
@@ -79,6 +83,7 @@ library
     FRP.Rhine.ClSF.Upsample
     FRP.Rhine.ClSF.Util
     FRP.Rhine.Clock
+    FRP.Rhine.Clock.Except
     FRP.Rhine.Clock.FixedStep
     FRP.Rhine.Clock.Periodic
     FRP.Rhine.Clock.Proxy
@@ -122,6 +127,7 @@ library
     dunai ^>=0.12.2,
     free >=5.1,
     monad-schedule ^>=0.1.2,
+    mtl >=2.2 && <2.4,
     random >=1.1,
     simple-affine-space ^>=0.2,
     text >=1.2 && <2.1,
@@ -139,13 +145,17 @@ test-suite test
   main-is: Main.hs
   other-modules:
     Clock
+    Clock.Except
     Clock.FixedStep
     Clock.Millisecond
+    Paths_rhine
     Schedule
     Util
 
+  autogen-modules: Paths_rhine
   build-depends:
     monad-schedule,
+    mtl,
     rhine,
     tasty ^>=1.4,
     tasty-hunit ^>=0.10,

--- a/rhine/rhine.cabal
+++ b/rhine/rhine.cabal
@@ -60,6 +60,7 @@ common opts
     DataKinds
     FlexibleContexts
     FlexibleInstances
+    ImportQualifiedPost
     MultiParamTypeClasses
     NamedFieldPuns
     NoStarIsType

--- a/rhine/src/FRP/Rhine/ClSF/Except.hs
+++ b/rhine/src/FRP/Rhine/ClSF/Except.hs
@@ -20,7 +20,7 @@ module FRP.Rhine.ClSF.Except (
 where
 
 -- base
-import qualified Control.Category as Category
+import Control.Category qualified as Category
 
 -- transformers
 import Control.Monad.Trans.Class (lift)
@@ -32,7 +32,7 @@ import Control.Monad.Trans.MSF.Except hiding (once, once_, throwOn, throwOn', th
 import Data.MonadicStreamFunction
 
 -- TODO Find out whether there is a cleverer way to handle exports
-import qualified Control.Monad.Trans.MSF.Except as MSFE
+import Control.Monad.Trans.MSF.Except qualified as MSFE
 
 -- rhine
 import FRP.Rhine.ClSF.Core

--- a/rhine/src/FRP/Rhine/ClSF/Random.hs
+++ b/rhine/src/FRP/Rhine/ClSF/Random.hs
@@ -21,7 +21,7 @@ import Control.Monad.Random
 -- dunai
 import Control.Monad.Trans.MSF.Except (performOnFirstSample)
 import Control.Monad.Trans.MSF.Random as X hiding (evalRandS, getRandomRS, getRandomRS_, getRandomS, runRandS)
-import qualified Control.Monad.Trans.MSF.Random as MSF
+import Control.Monad.Trans.MSF.Random qualified as MSF
 
 -- rhine
 import FRP.Rhine.ClSF.Core

--- a/rhine/src/FRP/Rhine/ClSF/Reader.hs
+++ b/rhine/src/FRP/Rhine/ClSF/Reader.hs
@@ -14,7 +14,7 @@ import Data.Tuple (swap)
 import Control.Monad.Trans.Reader
 
 -- dunai
-import qualified Control.Monad.Trans.MSF.Reader as MSF
+import Control.Monad.Trans.MSF.Reader qualified as MSF
 
 -- rhine
 import FRP.Rhine.ClSF.Core

--- a/rhine/src/FRP/Rhine/ClSF/Util.hs
+++ b/rhine/src/FRP/Rhine/ClSF/Util.hs
@@ -15,7 +15,7 @@ module FRP.Rhine.ClSF.Util where
 -- base
 import Control.Arrow
 import Control.Category (Category)
-import qualified Control.Category (id)
+import Control.Category qualified (id)
 import Data.Maybe (fromJust)
 import Data.Monoid (Last (Last), getLast)
 

--- a/rhine/src/FRP/Rhine/Clock.hs
+++ b/rhine/src/FRP/Rhine/Clock.hs
@@ -22,7 +22,7 @@ module FRP.Rhine.Clock (
 where
 
 -- base
-import qualified Control.Category as Category
+import Control.Category qualified as Category
 
 -- transformers
 import Control.Monad.IO.Class (MonadIO, liftIO)

--- a/rhine/src/FRP/Rhine/Clock/Except.hs
+++ b/rhine/src/FRP/Rhine/Clock/Except.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE ImportQualifiedPost #-}
-
 module FRP.Rhine.Clock.Except where
 
 -- base

--- a/rhine/src/FRP/Rhine/Clock/Except.hs
+++ b/rhine/src/FRP/Rhine/Clock/Except.hs
@@ -1,0 +1,213 @@
+{-# LANGUAGE ImportQualifiedPost #-}
+
+module FRP.Rhine.Clock.Except where
+
+-- base
+import Control.Arrow
+import Control.Exception
+import Control.Exception qualified as Exception
+import Control.Monad ((<=<))
+import Data.Functor ((<&>))
+import Data.Void
+
+-- transformers
+import Control.Monad.Trans.MSF.Except
+
+-- time
+import Data.Time (UTCTime, getCurrentTime)
+
+-- mtl
+import Control.Monad.Error.Class
+import Control.Monad.IO.Class (MonadIO, liftIO)
+import Control.Monad.Trans.MSF qualified as MSFExcept
+
+-- dunai
+import Control.Monad.Trans.MSF.Reader (readerS, runReaderS)
+import Data.MonadicStreamFunction (morphS)
+
+-- rhine
+import FRP.Rhine.ClSF.Core (ClSF)
+import FRP.Rhine.Clock (
+  Clock (..),
+  HoistClock (..),
+  TimeDomain,
+  TimeInfo (..),
+  retag,
+ )
+import FRP.Rhine.Clock.Proxy (GetClockProxy)
+
+-- * 'ExceptClock'
+
+{- | Handle 'IO' exceptions purely in 'ExceptT'.
+
+The clock @cl@ may throw 'Exception's of type @e@ while running.
+These exceptions are automatically caught, and raised as an error in 'ExceptT'
+(or more generally in 'MonadError', which implies the presence of 'ExceptT' in the monad transformer stack)
+
+It can then be caught and handled with 'CatchClock'.
+-}
+newtype ExceptClock cl e = ExceptClock {getExceptClock :: cl}
+
+instance (Exception e, Clock IO cl, MonadIO eio, MonadError e eio) => Clock eio (ExceptClock cl e) where
+  type Time (ExceptClock cl e) = Time cl
+  type Tag (ExceptClock cl e) = Tag cl
+
+  initClock ExceptClock {getExceptClock} = do
+    ioerror $
+      Exception.try $
+        initClock getExceptClock
+          <&> first (morphS (ioerror . Exception.try))
+    where
+      ioerror :: (MonadError e eio, MonadIO eio) => IO (Either e a) -> eio a
+      ioerror = liftEither <=< liftIO
+
+instance GetClockProxy (ExceptClock cl e)
+
+-- * 'CatchClock'
+
+{- | Catch an exception in one clock and proceed with another.
+
+When @cl1@ throws an exception @e@ (in @'ExceptT' e@) while running,
+this exception is caught, and a clock @cl2@ is started from the exception value.
+
+For this to be possible, @cl1@ must run in the monad @'ExceptT' e m@, while @cl2@ must run in @m@.
+To give @cl2@ the ability to throw another exception, you need to add a further 'ExceptT' layer to the stack in @m@.
+-}
+data CatchClock cl1 e cl2 = CatchClock cl1 (e -> cl2)
+
+instance (Time cl1 ~ Time cl2, Clock (ExceptT e m) cl1, Clock m cl2, Monad m) => Clock m (CatchClock cl1 e cl2) where
+  type Time (CatchClock cl1 e cl2) = Time cl1
+  type Tag (CatchClock cl1 e cl2) = Either (Tag cl2) (Tag cl1)
+  initClock (CatchClock cl1 handler) = do
+    tryToInit <- runExceptT $ first (>>> arr (second Right)) <$> initClock cl1
+    case tryToInit of
+      Right (runningClock, initTime) -> do
+        let catchingClock = safely $ do
+              e <- MSFExcept.try runningClock
+              let cl2 = handler e
+              (runningClock', _) <- once_ $ initClock cl2
+              safe $ runningClock' >>> arr (second Left)
+        return (catchingClock, initTime)
+      Left e -> (fmap (first (>>> arr (second Left))) . initClock) $ handler e
+
+instance (GetClockProxy (CatchClock cl1 e cl2))
+
+-- | Combine two 'ClSF's under two different clocks.
+catchClSF ::
+  (Time cl1 ~ Time cl2, Monad m) =>
+  -- | Executed until @cl1@ throws an exception
+  ClSF m cl1 a b ->
+  -- | Executed after @cl1@ threw an exception, when @cl2@ is started
+  ClSF m cl2 a b ->
+  ClSF m (CatchClock cl1 e cl2) a b
+catchClSF clsf1 clsf2 = readerS $ proc (timeInfo, a) -> do
+  case tag timeInfo of
+    Right tag1 -> runReaderS clsf1 -< (retag (const tag1) timeInfo, a)
+    Left tag2 -> runReaderS clsf2 -< (retag (const tag2) timeInfo, a)
+
+-- * 'SafeClock'
+
+-- | A clock that throws no exceptions.
+type SafeClock m = HoistClock (ExceptT Void m) m
+
+-- | Remove 'ExceptT' from the monad of a clock, proving that no exception can be thrown.
+safeClock :: (Functor m) => cl -> SafeClock m cl
+safeClock unhoistedClock =
+  HoistClock
+    { unhoistedClock
+    , monadMorphism = fmap (either absurd id) . runExceptT
+    }
+
+-- * 'Single' clock
+
+{- | A clock that emits a single tick, and then throws an exception.
+
+The tag, time measurement and exception have to be supplied as clock value.
+-}
+data Single m time tag e = Single
+  { singleTag :: tag
+  -- ^ The tag that will be emitted on the tick.
+  , getTime :: m time
+  -- ^ A method to measure the current time.
+  , exception :: e
+  -- ^ The exception to throw after the single tick.
+  }
+
+instance (TimeDomain time, MonadError e m) => Clock m (Single m time tag e) where
+  type Time (Single m time tag e) = time
+  type Tag (Single m time tag e) = tag
+  initClock Single {singleTag, getTime, exception} = do
+    initTime <- getTime
+    let runningClock = morphS (errorT . runExceptT) $ runMSFExcept $ do
+          step_ (initTime, singleTag)
+          return exception
+        errorT :: (MonadError e m) => m (Either e a) -> m a
+        errorT = (>>= liftEither)
+    return (runningClock, initTime)
+
+-- * 'DelayException'
+
+{- | Catch an exception in clock @cl@ and throw it after one time step.
+
+This is particularly useful if you want to give your signal network a chance to save its current state in some way.
+-}
+type DelayException m time cl e1 e2 = CatchClock cl e1 (Single m time e1 e2)
+
+-- | Construct a 'DelayException' clock.
+delayException ::
+  (Monad m, Clock (ExceptT e1 m) cl, MonadError e2 m) =>
+  -- | The clock that will throw an exception @e@
+  cl ->
+  -- | How to transform the exception into the new exception that will be thrown later
+  (e1 -> e2) ->
+  -- | How to measure the current time
+  m (Time cl) ->
+  DelayException m (Time cl) cl e1 e2
+delayException cl handler mTime = CatchClock cl $ \e -> Single e mTime $ handler e
+
+-- | Like 'delayException', but the exception thrown by @cl@ and by the @DelayException@ clock are the same.
+delayException' :: (Monad m, MonadError e m, Clock (ExceptT e m) cl) => cl -> m (Time cl) -> DelayException m (Time cl) cl e e
+delayException' cl = delayException cl id
+
+-- | Catch an 'IO' 'Exception', and throw it after one time step.
+type DelayMonadIOException m cl e1 e2 = DelayException m UTCTime (ExceptClock cl e1) e1 e2
+
+-- | Build a 'DelayMonadIOException'. The time will be measured using the system time.
+delayMonadIOException :: (Exception e1, MonadIO m, MonadError e2 m, Clock IO cl, Time cl ~ UTCTime) => cl -> (e1 -> e2) -> DelayMonadIOException m cl e1 e2
+delayMonadIOException cl handler = delayException (ExceptClock cl) handler $ liftIO getCurrentTime
+
+-- | 'DelayMonadIOException' specialised to 'IOError'.
+type DelayMonadIOError m cl e = DelayMonadIOException m cl IOError e
+
+-- | 'delayMonadIOException' specialised to 'IOError'.
+delayMonadIOError :: (Exception e, MonadError e m, MonadIO m, Clock IO cl, Time cl ~ UTCTime) => cl -> (IOError -> e) -> DelayMonadIOError m cl e
+delayMonadIOError = delayMonadIOException
+
+-- | Like 'delayMonadIOError', but throw the error without transforming it.
+delayMonadIOError' :: (MonadError IOError m, MonadIO m, Clock IO cl, Time cl ~ UTCTime) => cl -> DelayMonadIOError m cl IOError
+delayMonadIOError' cl = delayMonadIOError cl id
+
+{- | 'DelayMonadIOException' specialised to the monad @'ExceptT' e2 'IO'@.
+
+This is sometimes helpful when the type checker complains about an ambigous monad type variable.
+-}
+type DelayIOException cl e1 e2 = DelayException (ExceptT e2 IO) UTCTime (ExceptClock cl e1) e1 e2
+
+-- | 'delayMonadIOException' specialised to the monad @'ExceptT' e2 'IO'@.
+delayIOException :: (Exception e1, Clock IO cl, Time cl ~ UTCTime) => cl -> (e1 -> e2) -> DelayIOException cl e1 e2
+delayIOException = delayMonadIOException
+
+-- | 'delayIOException'', but throw the error without transforming it.
+delayIOException' :: (Exception e, Clock IO cl, Time cl ~ UTCTime) => cl -> DelayIOException cl e e
+delayIOException' cl = delayIOException cl id
+
+-- | 'DelayIOException' specialised to 'IOError'.
+type DelayIOError cl e = DelayIOException cl IOError e
+
+-- | 'delayIOException' specialised to 'IOError'.
+delayIOError :: (Time cl ~ UTCTime, Clock IO cl) => cl -> (IOError -> e) -> DelayIOError cl e
+delayIOError = delayIOException
+
+-- | 'delayIOError', but throw the error without transforming it.
+delayIOError' :: (Time cl ~ UTCTime, Clock IO cl) => cl -> DelayIOError cl IOError
+delayIOError' cl = delayIOException cl id

--- a/rhine/src/FRP/Rhine/Clock/Realtime/Stdin.hs
+++ b/rhine/src/FRP/Rhine/Clock/Realtime/Stdin.hs
@@ -16,8 +16,8 @@ import Data.Time.Clock
 import Control.Monad.IO.Class
 
 -- text
-import qualified Data.Text as Text
-import qualified Data.Text.IO as Text
+import Data.Text qualified as Text
+import Data.Text.IO qualified as Text
 
 -- rhine
 import FRP.Rhine.Clock

--- a/rhine/src/FRP/Rhine/Clock/Unschedule.hs
+++ b/rhine/src/FRP/Rhine/Clock/Unschedule.hs
@@ -5,7 +5,7 @@
 module FRP.Rhine.Clock.Unschedule where
 
 -- base
-import qualified Control.Concurrent as Concurrent (yield)
+import Control.Concurrent qualified as Concurrent (yield)
 import Control.Monad.IO.Class
 
 -- monad-schedule

--- a/rhine/src/FRP/Rhine/Schedule.hs
+++ b/rhine/src/FRP/Rhine/Schedule.hs
@@ -18,7 +18,7 @@ module FRP.Rhine.Schedule where
 
 -- base
 import Data.List.NonEmpty (NonEmpty (..))
-import qualified Data.List.NonEmpty as N
+import Data.List.NonEmpty qualified as N
 
 -- dunai
 import Data.MonadicStreamFunction

--- a/rhine/test/Clock.hs
+++ b/rhine/test/Clock.hs
@@ -4,12 +4,14 @@ module Clock where
 import Test.Tasty
 
 -- rhine
+import Clock.Except
 import Clock.FixedStep
 import Clock.Millisecond
 
 tests =
   testGroup
     "Clock"
-    [ Clock.FixedStep.tests
+    [ Clock.Except.tests
+    , Clock.FixedStep.tests
     , Clock.Millisecond.tests
     ]

--- a/rhine/test/Clock/Except.hs
+++ b/rhine/test/Clock/Except.hs
@@ -1,0 +1,184 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Clock.Except where
+
+-- base
+import Control.Applicative (Alternative (empty))
+import Data.Either (isLeft)
+import GHC.IO.Handle (hDuplicateTo)
+import System.IO (IOMode (ReadMode), stdin, withFile)
+import System.IO.Error (isEOFError)
+
+-- mtl
+import Control.Monad.Writer.Class
+
+-- transformers
+-- Replace Strict by CPS when bumping mtl to 2.3
+import Control.Monad.Trans.Class (lift)
+import Control.Monad.Trans.Maybe (MaybeT (..))
+import Control.Monad.Trans.Writer.Strict hiding (tell)
+
+-- text
+import Data.Text (Text)
+
+-- tasty
+import Test.Tasty (TestTree, testGroup)
+
+-- tasty-hunit
+import Test.Tasty.HUnit (testCase, (@?), (@?=))
+
+-- rhine
+import FRP.Rhine
+import FRP.Rhine.Clock.Except (
+  CatchClock (CatchClock),
+  DelayIOError,
+  DelayMonadIOError,
+  ExceptClock (ExceptClock),
+  catchClSF,
+  delayIOError,
+  delayMonadIOError',
+ )
+import Paths_rhine
+
+tests :: TestTree
+tests =
+  testGroup
+    "Except"
+    [exceptClockTests, catchClockTests, delayedClockTests, innerWriterTests]
+
+-- * 'Except'
+
+type E = ExceptT IOError IO
+type EClock = ExceptClock StdinClock IOError
+
+exceptClock :: EClock
+exceptClock = ExceptClock StdinClock
+
+exceptClockTests :: TestTree
+exceptClockTests =
+  testGroup
+    "ExceptClock"
+    [ testCase "Raises the exception in ExceptT on EOF" $ withTestStdin $ do
+        Left result <- runExceptT $ flow $ clId @@ exceptClock
+        isEOFError result @? "It's an EOF error"
+    ]
+
+-- ** 'CatchClock'
+
+type TestCatchClock = CatchClock EClock IOError EClock
+
+testClock :: TestCatchClock
+testClock = CatchClock exceptClock $ const exceptClock
+
+type ME = MaybeT E
+type TestCatchClockMaybe = CatchClock EClock IOError (LiftClock E MaybeT (LiftClock IO (ExceptT IOError) Busy))
+
+testClockMaybe :: TestCatchClockMaybe
+testClockMaybe = CatchClock exceptClock (const (liftClock (liftClock Busy)))
+
+catchClockTests :: TestTree
+catchClockTests =
+  testGroup
+    "CatchClock"
+    [ testCase "Outputs the exception of the second clock as well" $ withTestStdin $ do
+        Left result <- runExceptT $ flow $ clId @@ testClock
+        isEOFError result @? "It's an EOF error"
+    , testCase "Can recover from an exception" $ withTestStdin $ do
+        let stopInClsf :: ClSF ME TestCatchClockMaybe () ()
+            stopInClsf = catchClSF clId $ constMCl empty
+        result <- runExceptT $ runMaybeT $ flow $ stopInClsf @@ testClockMaybe
+        result @?= Right Nothing
+    ]
+
+-- ** Clock failing at init
+
+{- | This clock throws an exception at initialization.
+
+Useful for testing clock initialization.
+-}
+data FailingClock = FailingClock
+
+instance (Monad m) => Clock (ExceptT () m) FailingClock where
+  type Time FailingClock = UTCTime
+  type Tag FailingClock = ()
+  initClock FailingClock = throwE ()
+
+instance GetClockProxy FailingClock
+
+type CatchFailingClock = CatchClock FailingClock () Busy
+
+catchFailingClock :: CatchFailingClock
+catchFailingClock = CatchClock FailingClock $ const Busy
+
+failingClockTests :: TestTree
+failingClockTests =
+  testGroup
+    "FailingClock"
+    [ testCase "flow fails immediately" $ do
+        result <- runExceptT $ flow $ clId @@ FailingClock
+        result @?= Left ()
+    , testCase "CatchClock recovers from failure at init" $ do
+        let
+          clsfStops :: ClSF (MaybeT IO) CatchFailingClock () ()
+          clsfStops = catchClSF clId $ constM $ lift empty
+        result <- runMaybeT $ flow $ clsfStops @@ catchFailingClock
+        result @?= Nothing -- The ClSF stopped the execution, not the clock
+    ]
+
+-- ** 'DelayException'
+
+type DelayedClock = DelayIOError StdinClock (Maybe [Text])
+
+delayedClock :: DelayedClock
+delayedClock = delayIOError StdinClock $ const Nothing
+
+delayedClockTests :: TestTree
+delayedClockTests =
+  testGroup
+    "DelayedClock"
+    [ testCase "DelayException delays error by 1 step" $ withTestStdin $ do
+        let
+          throwCollectedText :: ClSF (ExceptT (Maybe [Text]) IO) DelayedClock () ()
+          throwCollectedText = proc () -> do
+            tag <- tagS -< ()
+            textSoFar <- mappendS -< either (const []) pure tag
+            throwOn' -< (isLeft tag, Just textSoFar)
+        result <- runExceptT $ flow $ throwCollectedText @@ delayedClock
+        result @?= Left (Just ["data", "test"])
+    , testCase "DelayException throws error after 1 step" $ withTestStdin $ do
+        let
+          dontThrow :: ClSF (ExceptT (Maybe [Text]) IO) DelayedClock () ()
+          dontThrow = clId
+        result <- runExceptT $ flow $ dontThrow @@ delayedClock
+        result @?= Left Nothing
+    ]
+
+-- ** Inner writer
+
+{- | 'WriterT' is now the inner monad, meaning that the log survives exceptions.
+This way, the state is not lost.
+-}
+type ClWriterExcept = DelayMonadIOError (ExceptT IOError (WriterT [Text] IO)) StdinClock IOError
+
+clWriterExcept :: ClWriterExcept
+clWriterExcept = delayMonadIOError' StdinClock
+
+innerWriterTests :: TestTree
+innerWriterTests = testCase "DelayException throws error after 1 step, but can write down results" $ withTestStdin $ do
+  let
+    tellStdin :: (MonadWriter [Text] m) => ClSF m ClWriterExcept () ()
+    tellStdin = catchClSF (tagS >>> arrMCl (tell . pure)) clId
+
+  (Left e, result) <- runWriterT $ runExceptT $ flow $ tellStdin @@ clWriterExcept
+  isEOFError e @? "is EOF"
+  result @?= ["test", "data"]
+
+-- * Test helpers
+
+-- | Emulate test standard input
+withTestStdin :: IO a -> IO a
+withTestStdin action = do
+  testdataFile <- getDataFileName "test/assets/testdata.txt"
+  withFile testdataFile ReadMode $ \h -> do
+    hDuplicateTo h stdin
+    action

--- a/rhine/test/assets/testdata.txt
+++ b/rhine/test/assets/testdata.txt
@@ -1,0 +1,2 @@
+test
+data


### PR DESCRIPTION
Introduces some form of control flow for clocks. Clocks may now throw exceptions, and other clocks can be started as exception handlers.

* [x] Clean up git history
* [x] Figure out whether there are ways to catch the clock exception without discarding the state of the clsf
* [x] Reduce redundancy between IO errors and `ExceptT`. 
  * [x] Merge only `ExceptT` versions here, open separate PR for IO versions, needs to add benchmarks (to be merged after #285 ). See https://github.com/turion/rhine/pull/300