### PR TITLE
Add Never clock

### DIFF
--- a/rhine/ChangeLog.md
+++ b/rhine/ChangeLog.md
@@ -1,5 +1,9 @@
 # Revision history for rhine
 
+## 1.2.1
+
+* Added `FRP.Rhine.Clock.Realtime.Never` (clock that never ticks)
+
 ## 1.2
 
 * Changed Stdin clock Tag type to Text

--- a/rhine/rhine.cabal
+++ b/rhine/rhine.cabal
@@ -86,6 +86,7 @@ library
     FRP.Rhine.Clock.Realtime.Busy
     FRP.Rhine.Clock.Realtime.Event
     FRP.Rhine.Clock.Realtime.Millisecond
+    FRP.Rhine.Clock.Realtime.Never
     FRP.Rhine.Clock.Realtime.Stdin
     FRP.Rhine.Clock.Select
     FRP.Rhine.Clock.Unschedule

--- a/rhine/src/FRP/Rhine.hs
+++ b/rhine/src/FRP/Rhine.hs
@@ -38,6 +38,7 @@ import FRP.Rhine.Clock.Realtime.Audio as X
 import FRP.Rhine.Clock.Realtime.Busy as X
 import FRP.Rhine.Clock.Realtime.Event as X
 import FRP.Rhine.Clock.Realtime.Millisecond as X
+import FRP.Rhine.Clock.Realtime.Never as X
 import FRP.Rhine.Clock.Realtime.Stdin as X
 import FRP.Rhine.Clock.Select as X
 import FRP.Rhine.Clock.Unschedule as X

--- a/rhine/src/FRP/Rhine/Clock/Realtime/Never.hs
+++ b/rhine/src/FRP/Rhine/Clock/Realtime/Never.hs
@@ -1,0 +1,36 @@
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeFamilies #-}
+
+-- | A clock that never ticks.
+module FRP.Rhine.Clock.Realtime.Never where
+
+-- base
+import Control.Concurrent (threadDelay)
+import Control.Monad (forever)
+import Data.Void (Void)
+
+-- time
+import Data.Time.Clock
+
+-- rhine
+import FRP.Rhine.Clock
+import FRP.Rhine.Clock.Proxy
+
+-- transformers
+import Control.Monad.IO.Class
+
+-- | A clock that never ticks.
+data Never = Never
+
+instance (MonadIO m) => Clock m Never where
+  type Time Never = UTCTime
+  type Tag Never = Void
+
+  initClock _ = do
+    initialTime <- liftIO getCurrentTime
+    return
+      ( constM (liftIO . forever . threadDelay $ 10 ^ 9)
+      , initialTime
+      )
+
+instance GetClockProxy Never


### PR DESCRIPTION
As seen in: https://github.com/ners/rhine-linux/blob/master/kitchen-sink/Main.hs

Some clocks may fail to initialise (e.g. because they depend on missing external resources), but we would like to recover gracefully by replacing them with a clock that never ticks.

And so we introduce a clock that never ticks, but can produce anything:

```haskell
initFallibleClock
    :: forall m cl
     . ( Clock m cl
       , MonadIO m
       , MonadCatch m
       , Time cl ~ Time Never
       )
    => cl
    -> RunningClockInit m (Time cl) (Tag cl)
initFallibleClock cl = catchAll (initClock cl) $ const $ initClock Never <&> first (>>^ second absurd)
```