### PR TITLE
Rewrite Nix flake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+      - name: Free disk space
+        run: |
+          if [ "$(uname --kernel-name)" = "Linux" ]; then
+            sudo rm -rf /usr/local/* /usr/share/* /opt/*
+            docker rmi $(docker image ls -aq)
+          fi
       - uses: cachix/install-nix-action@V27
       - uses: DeterminateSystems/magic-nix-cache-action@v7
       - uses: cachix/cachix-action@v15

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,10 @@ jobs:
         with:
           name: rhine
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - name: Check whether .nix files are formatted
+        run: |
+          nix fmt
+          git diff --exit-code
       - name: Build all packages
         run: nix build --accept-flake-config
       - name: Run tests

--- a/default.nix
+++ b/default.nix
@@ -1,9 +1,0 @@
-let
-  lock = builtins.fromJSON (builtins.readFile ./flake.lock);
-  flake-compat-src = fetchTarball {
-    url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
-    sha256 = lock.nodes.flake-compat.locked.narHash;
-  };
-  flake-compat = import flake-compat-src { src =  ./.; };
-in
-flake-compat.defaultNix

--- a/flake.lock
+++ b/flake.lock
@@ -1,66 +1,12 @@
 {
   "nodes": {
-    "flake-compat": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "haskell-flake-utils": {
-      "inputs": {
-        "flake-utils": [
-          "flake-utils"
-        ]
-      },
-      "locked": {
-        "lastModified": 1707809372,
-        "narHash": "sha256-wfTL9PlCSOqSSyU4eenFFI7pHrV21gba4GEILnI4nAU=",
-        "owner": "ivanovs-4",
-        "repo": "haskell-flake-utils",
-        "rev": "3cbdc5d6093e8b4464ae64097e0c8c61e4414ff2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "ivanovs-4",
-        "repo": "haskell-flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1715571466,
-        "narHash": "sha256-7o7OwQ7D35K7fsBaDjEqHfpbbg+EKhAtz93cHg3LXBw=",
+        "lastModified": 1720801720,
+        "narHash": "sha256-PjXn2DUkwcN+58/C5XCOqsitGwN2u/WkYdC/ugP+3jQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "adc44ac0ee8454f4f51ef5dd1bdcc60080141e24",
+        "rev": "2d419e7e0024cb7448aace8faf64b2c6ff26a70d",
         "type": "github"
       },
       "original": {
@@ -72,25 +18,7 @@
     },
     "root": {
       "inputs": {
-        "flake-compat": "flake-compat",
-        "flake-utils": "flake-utils",
-        "haskell-flake-utils": "haskell-flake-utils",
         "nixpkgs": "nixpkgs"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -22,81 +22,122 @@
 
       # The names of all Haskell packages in this repository, defined as all the directories with *.cabal files in them.
       pnames = map (path: baseNameOf (dirOf path)) (lib.fileset.toList (lib.fileset.fileFilter (file: file.hasExt "cabal") ./.));
+
+      # All GHC versions that this project is tested with.
+      # To be kept in sync with the `tested-with:` section in rhine.cabal.
+      # To do: Automated check whether this is the same as what get-tested returns.
+      # Currently blocked on https://github.com/Kleidukos/get-tested/issues/39
       supportedGhcs = [ "ghc92" "ghc94" "ghc96" "ghc98" ];
+
+      # All Haskell packages defined here that contain a library section
       libPnames = filter (pname: pname != "rhine-examples") pnames;
+
+      # The Haskell packages set, for every supported GHC version
       hpsFor = pkgs:
         lib.filterAttrs (name: _: elem name supportedGhcs) pkgs.haskell.packages
         // { default = pkgs.haskellPackages; };
+
+      # A haskellPackages overlay containing everything defined in this repo
       rhinePackages = hfinal: hprev:
         lib.genAttrs pnames (pname: hfinal.callCabal2nix pname ./${pname} { });
+
+      # A nixpkgs overlay containing everything defined in this repo, for reuse in downstream projects
       overlay = final: prev:
-        let hps = hpsFor final; in {
+        let
+          hps = hpsFor final;
+
+          # Overrides that are necessary because of dependencies not being up to date or fixed yet in nixpkgs.
+          # Check on nixpkgs bumps whether some of these can be removed.
+          temporaryHaskellOverrides = with prev.haskell.lib.compose; [
+            (hfinal: hprev: {
+              monad-bayes = markUnbroken hprev.monad-bayes;
+              monad-schedule = hprev.callHackageDirect
+                {
+                  pkg = "monad-schedule";
+                  ver = "0.2";
+                  sha256 = "sha256-Z9lAxkvJDH9aQZd65bGOQI3EGH7oSAhK0nuBKULgiCE=";
+                }
+                { };
+              time-domain = hprev.callHackageDirect
+                {
+                  pkg = "time-domain";
+                  ver = "0.1.0.5";
+                  sha256 = "sha256-llDBQuU5ez/0MiOIMH97P4BQhFDyPfTMWinq1wJrDGI=";
+                }
+                { };
+            })
+            (hfinal: hprev: lib.optionalAttrs prev.stdenv.isDarwin {
+              monad-schedule = dontCheck hprev.monad-schedule;
+            })
+            (hfinal: hprev: lib.optionalAttrs (lib.versionOlder hprev.ghc.version "9.4") {
+              time-domain = doJailbreak hprev.time-domain;
+            })
+          ];
+
+        in
+        {
+          # The Haskell package set containing the packages defined in this repo
           haskell = prev.haskell // {
-            packageOverrides = with prev.haskell.lib.compose; lib.composeManyExtensions [
+            packageOverrides = with prev.haskell.lib.compose; lib.composeManyExtensions ([
               prev.haskell.packageOverrides
               rhinePackages
-              (hfinal: hprev: {
-                monad-bayes = markUnbroken hprev.monad-bayes;
-                monad-schedule = hprev.callHackageDirect
-                  {
-                    pkg = "monad-schedule";
-                    ver = "0.2";
-                    sha256 = "sha256-Z9lAxkvJDH9aQZd65bGOQI3EGH7oSAhK0nuBKULgiCE=";
-                  }
-                  { };
-                time-domain = hprev.callHackageDirect
-                  {
-                    pkg = "time-domain";
-                    ver = "0.1.0.5";
-                    sha256 = "sha256-llDBQuU5ez/0MiOIMH97P4BQhFDyPfTMWinq1wJrDGI=";
-                  }
-                  { };
-              })
-              (hfinal: hprev: lib.optionalAttrs prev.stdenv.isDarwin {
-                monad-schedule = dontCheck hprev.monad-schedule;
-              })
-              (hfinal: hprev: lib.optionalAttrs (lib.versionOlder hprev.ghc.version "9.4") {
-                time-domain = doJailbreak hprev.time-domain;
-              })
-            ];
+            ] ++ temporaryHaskellOverrides);
           };
-          rhine-bin = prev.buildEnv {
-            name = "rhine-bin";
-            paths = map (pname: hps.default.${pname}) pnames;
-            pathsToLink = [ "/bin" ];
-          };
-          rhine-lib = prev.buildEnv {
-            name = "rhine-lib";
-            paths = lib.mapCartesianProduct
-              ({ hp, pname }: hp.${pname})
-              { hp = attrValues hps; pname = pnames; };
-            pathsToLink = [ "/lib" ];
-          };
-          rhine-docs = prev.buildEnv {
-            name = "rhine-docs";
-            paths = map (pname: prev.haskell.lib.documentationTarball hps.default.${pname}) libPnames;
-          };
-          rhine-sdist = prev.buildEnv {
-            name = "rhine-sdist";
-            paths = map (pname: prev.haskell.lib.sdistTarball hps.default.${pname}) libPnames;
-          };
-          rhine-all = prev.symlinkJoin {
-            name = "rhine-all";
-            paths = with final; [ rhine-bin rhine-lib ];
-            postBuild = ''
-              ln -s ${final.rhine-docs} $out/docs
-              ln -s ${final.rhine-sdist} $out/sdist
-            '';
-          };
+
+          # Helper packages containing aspects of the whole rhine build:
+          # All executables, built with the nixpkgs-default GHC
+          rhine-bin = prev.buildEnv
+            {
+              name = "rhine-bin";
+              paths = map (pname: hps.default.${pname}) pnames;
+              pathsToLink = [ "/bin" ];
+            };
+          # All libraries for all GHC versions
+          rhine-lib = prev.buildEnv
+            {
+              name = "rhine-lib";
+              paths = lib.mapCartesianProduct
+                ({ hp, pname }: hp.${pname})
+                { hp = attrValues hps; pname = pnames; };
+              pathsToLink = [ "/lib" ];
+            };
+          # All haddocks
+          rhine-docs = prev.buildEnv
+            {
+              name = "rhine-docs";
+              paths = map (pname: prev.haskell.lib.documentationTarball hps.default.${pname}) libPnames;
+            };
+          # All sdist tarballs for Hackage publication
+          rhine-sdist = prev.buildEnv
+            {
+              name = "rhine-sdist";
+              paths = map (pname: prev.haskell.lib.sdistTarball hps.default.${pname}) libPnames;
+            };
+
+          # All rhine build products
+          rhine-all = prev.symlinkJoin
+            {
+              name = "rhine-all";
+              paths = with final; [ rhine-bin rhine-lib ];
+              postBuild = ''
+                ln -s ${final.rhine-docs} $out/docs
+                ln -s ${final.rhine-sdist} $out/sdist
+              '';
+            };
         };
+
+      # Helper to build a flake output for all systems that are defined in nixpkgs
       forAllPlatforms = f:
         mapAttrs (system: pkgs: f system (pkgs.extend overlay)) inputs.nixpkgs.legacyPackages;
     in
     {
+      # Reexport the overlay so other downstream flakes can use it to develop rhine projects with low effort.
       overlays.default = overlay;
 
+      # Usage: nix fmt
       formatter = forAllPlatforms (system: pkgs: pkgs.nixpkgs-fmt);
 
+      # Usage: nix build # This builds all rhine packages on all GHCs
       packages = forAllPlatforms (system: pkgs: {
         default = pkgs.rhine-all;
       });
@@ -105,6 +146,7 @@
         inherit (pkgs) haskell haskellPackages rhine-all;
       });
 
+      # Usage: nix develop .#ghc98
       devShells = forAllPlatforms (systems: pkgs: mapAttrs
         (_: hp: hp.shellFor {
           packages = ps: map (pname: ps.${pname}) pnames;

--- a/flake.nix
+++ b/flake.nix
@@ -34,7 +34,7 @@
 
       # The Haskell packages set, for every supported GHC version
       hpsFor = pkgs:
-        lib.filterAttrs (name: _: elem name supportedGhcs) pkgs.haskell.packages
+        lib.genAttrs supportedGhcs (ghc: pkgs.haskell.packages.${ghc})
         // { default = pkgs.haskellPackages; };
 
       # A haskellPackages overlay containing everything defined in this repo

--- a/flake.nix
+++ b/flake.nix
@@ -118,11 +118,11 @@
           rhine-all = prev.symlinkJoin
             {
               name = "rhine-all";
-              paths = with final; [ rhine-bin rhine-lib ];
-              postBuild = ''
-                ln -s ${final.rhine-docs} $out/docs
-                ln -s ${final.rhine-sdist} $out/sdist
-              '';
+              paths = with final; [
+                rhine-bin
+                rhine-lib
+                (prev.linkFarm "docsAndSdist" { docs = final.rhine-docs; sdist = rhine-sdist; })
+              ];
             };
         };
 

--- a/flake.nix
+++ b/flake.nix
@@ -19,14 +19,9 @@
     with builtins;
     let
       lib = inputs.nixpkgs.lib;
-      pnames = [
-        "automaton"
-        "rhine"
-        "rhine-bayes"
-        "rhine-examples"
-        "rhine-gloss"
-        "rhine-terminal"
-      ];
+
+      # The names of all Haskell packages in this repository, defined as all the directories with *.cabal files in them.
+      pnames = map (path: baseNameOf (dirOf path)) (lib.fileset.toList (lib.fileset.fileFilter (file: file.hasExt "cabal") ./.));
       supportedGhcs = [ "ghc92" "ghc94" "ghc96" "ghc98" ];
       libPnames = filter (pname: pname != "rhine-examples") pnames;
       hpsFor = pkgs:

--- a/flake.nix
+++ b/flake.nix
@@ -161,6 +161,7 @@
         (_: hp: hp.shellFor {
           packages = ps: map (pname: ps.${pname}) pnames;
           nativeBuildInputs = with hp; [
+            cabal-gild
             cabal-install
             fourmolu
             haskell-language-server

--- a/flake.nix
+++ b/flake.nix
@@ -13,56 +13,112 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable-small";
-    flake-utils.url = "github:numtide/flake-utils";
-
-    flake-compat = {
-      url = "github:edolstra/flake-compat";
-      flake = false;
-    };
-
-    haskell-flake-utils = {
-      url = "github:ivanovs-4/haskell-flake-utils";
-      inputs.flake-utils.follows = "flake-utils";
-    };
   };
 
-outputs = { self, nixpkgs, flake-utils, haskell-flake-utils, flake-compat, ... }:
-  haskell-flake-utils.lib.simpleCabalProject2flake {
-    inherit self nixpkgs;
+  outputs = inputs:
+    with builtins;
+    let
+      lib = inputs.nixpkgs.lib;
+      pnames = [
+        "automaton"
+        "rhine"
+        "rhine-bayes"
+        "rhine-examples"
+        "rhine-gloss"
+        "rhine-terminal"
+      ];
+      supportedGhcs = [ "ghc92" "ghc94" "ghc96" "ghc98" ];
+      libPnames = filter (pname: pname != "rhine-examples") pnames;
+      hpsFor = pkgs:
+        lib.filterAttrs (name: _: elem name supportedGhcs) pkgs.haskell.packages
+        // { default = pkgs.haskellPackages; };
+      rhinePackages = hfinal: hprev:
+        lib.genAttrs pnames (pname: hfinal.callCabal2nix pname ./${pname} { });
+      overlay = final: prev:
+        let hps = hpsFor final; in {
+          haskell = prev.haskell // {
+            packageOverrides = with prev.haskell.lib.compose; lib.composeManyExtensions [
+              prev.haskell.packageOverrides
+              rhinePackages
+              (hfinal: hprev: {
+                monad-bayes = markUnbroken hprev.monad-bayes;
+                monad-schedule = hprev.callHackageDirect
+                  {
+                    pkg = "monad-schedule";
+                    ver = "0.2";
+                    sha256 = "sha256-Z9lAxkvJDH9aQZd65bGOQI3EGH7oSAhK0nuBKULgiCE=";
+                  }
+                  { };
+                time-domain = hprev.callHackageDirect
+                  {
+                    pkg = "time-domain";
+                    ver = "0.1.0.5";
+                    sha256 = "sha256-llDBQuU5ez/0MiOIMH97P4BQhFDyPfTMWinq1wJrDGI=";
+                  }
+                  { };
+              })
+              (hfinal: hprev: lib.optionalAttrs prev.stdenv.isDarwin {
+                monad-schedule = dontCheck hprev.monad-schedule;
+              })
+              (hfinal: hprev: lib.optionalAttrs (lib.versionOlder hprev.ghc.version "9.4") {
+                time-domain = doJailbreak hprev.time-domain;
+              })
+            ];
+          };
+          rhine-bin = prev.buildEnv {
+            name = "rhine-bin";
+            paths = map (pname: hps.default.${pname}) pnames;
+            pathsToLink = [ "/bin" ];
+          };
+          rhine-lib = prev.buildEnv {
+            name = "rhine-lib";
+            paths = lib.mapCartesianProduct
+              ({ hp, pname }: hp.${pname})
+              { hp = attrValues hps; pname = pnames; };
+            pathsToLink = [ "/lib" ];
+          };
+          rhine-docs = prev.buildEnv {
+            name = "rhine-docs";
+            paths = map (pname: prev.haskell.lib.documentationTarball hps.default.${pname}) libPnames;
+          };
+          rhine-sdist = prev.buildEnv {
+            name = "rhine-sdist";
+            paths = map (pname: prev.haskell.lib.sdistTarball hps.default.${pname}) libPnames;
+          };
+          rhine-all = prev.symlinkJoin {
+            name = "rhine-all";
+            paths = with final; [ rhine-bin rhine-lib ];
+            postBuild = ''
+              ln -s ${final.rhine-docs} $out/docs
+              ln -s ${final.rhine-sdist} $out/sdist
+            '';
+          };
+        };
+      forAllPlatforms = f:
+        mapAttrs (system: pkgs: f system (pkgs.extend overlay)) inputs.nixpkgs.legacyPackages;
+    in
+    {
+      overlays.default = overlay;
 
-    systems = [
-      # Tested in CI
-      "x86_64-linux"
-      "x86_64-darwin"
-      # Tested by maintainers
-      "aarch64-darwin"
-      # Not sure we can test this in CI
-      "i686-linux"
-    ];
+      formatter = forAllPlatforms (system: pkgs: pkgs.nixpkgs-fmt);
 
-    hpPreOverrides = { pkgs, ... }: self: super:
-      with pkgs.haskell.lib;
-      with haskell-flake-utils.lib;
-      {
-        monad-schedule = dontCheck (super.callHackageDirect {
-          pkg = "monad-schedule";
-          ver = "0.2";
-          sha256 = "sha256-Z9lAxkvJDH9aQZd65bGOQI3EGH7oSAhK0nuBKULgiCE=";
-        } {});
-        time-domain = super.callHackageDirect {
-          pkg = "time-domain";
-          ver = "0.1.0.4";
-          sha256 = "sha256-6o0dsCDUSjyBx7X979o3oDSRbrWYvkf45DUF5AyvbGY=";
-        } {};
-        brick = super.brick_2_3_1; # monad-bayes
-        monad-bayes = dontCheck (super.callHackageDirect {
-          pkg = "monad-bayes";
-          ver = "1.3.0.1";
-          sha256 = "sha256-66IUFRWNY7flGR3Qb22keSb3FDP4zIjoYXfRH7yvCts=";
-        } {});
-      };
+      packages = forAllPlatforms (system: pkgs: {
+        default = pkgs.rhine-all;
+      });
 
-    name = "rhine";
-    packageNames = [ "automaton" "rhine-gloss" "rhine-terminal" "rhine-examples" "rhine-bayes" ];
-  };
+      legacyPackages = forAllPlatforms (system: pkgs: {
+        inherit (pkgs) haskell haskellPackages rhine-all;
+      });
+
+      devShells = forAllPlatforms (systems: pkgs: mapAttrs
+        (_: hp: hp.shellFor {
+          packages = ps: map (pname: ps.${pname}) pnames;
+          nativeBuildInputs = with hp; [
+            cabal-install
+            fourmolu
+            haskell-language-server
+          ];
+        })
+        (hpsFor pkgs));
+    };
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,9 +1,0 @@
-let
-  lock = builtins.fromJSON (builtins.readFile ./flake.lock);
-  flake-compat-src = fetchTarball {
-    url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
-    sha256 = lock.nodes.flake-compat.locked.narHash;
-  };
-  flake-compat = import flake-compat-src { src =  ./.; };
-in
-flake-compat.shellNix


### PR DESCRIPTION
As discussed at ZuriHac: the new and improved Rhine flake! ✨

Design goals:
 - minimise external dependencies; only Nixpkgs
 - use Nixpkgs to support all platforms and GHC versions
 - composability: expose an overlay that can be used by others

This is the sort of flake I wish to import when working on Rhine-powered projects. Until now I've had to copy around a bunch of boilerplate.