### PR TITLE
Fix monad-schedule flake input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,14 +129,14 @@ jobs:
         run: |
           nix fmt
           git diff --exit-code
+      - name: Flake check
+        run: nix flake check
       - name: Build all packages
         run: nix build --accept-flake-config
       - name: Run tests
         run: |
           nix develop --accept-flake-config -c cabal update
           nix develop --accept-flake-config -c cabal test all
-      # nix flake check breaks on IFD in multi-platform flake https://github.com/NixOS/nix/issues/4265
-      # - run: nix flake check
 
   cabal-check:
     name: Check and format all cabal files

--- a/flake.lock
+++ b/flake.lock
@@ -2,14 +2,16 @@
   "nodes": {
     "monad-schedule": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
-        "lastModified": 1730099708,
-        "narHash": "sha256-Usw6nWADyK3LL9dQ98H3GAxwI+FgtbzA4Us3MngyF64=",
+        "lastModified": 1731107003,
+        "narHash": "sha256-au6hQM8V4lZtYiwYZl88pAr7xNtFit3pQR0AXvUTuyo=",
         "owner": "turion",
         "repo": "monad-schedule",
-        "rev": "a891aa90747bc01fa6f34794d748aa316d905ce2",
+        "rev": "f6651c56975bd9e126b9d1d5c8eed0a304d38a30",
         "type": "github"
       },
       "original": {
@@ -20,27 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1721258662,
-        "narHash": "sha256-EgRErDL4Xj0Mkz2ZqDJ1fIcebLJpvMKtF/lb+WJ8y+I=",
+        "lastModified": 1731569569,
+        "narHash": "sha256-yUjNI34R68uLg95nHzINg8ulpL77p4kOqUsCkMm1F28=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ede8a2b8473fae013cfc0cca9400a8fcbd7cc021",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable-small",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1730858696,
-        "narHash": "sha256-us4xhqqW6OkjCihXYuFArhwx91cTzns8FEY8lE4v7JQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "8541b4db5adb9dd835ed5d0023dec229987b7391",
+        "rev": "7f2d3d2febedabd8f5c9761373c99b9dcfa917e1",
         "type": "github"
       },
       "original": {
@@ -53,7 +39,7 @@
     "root": {
       "inputs": {
         "monad-schedule": "monad-schedule",
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,10 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable-small";
-    monad-schedule.url = "github:turion/monad-schedule";
+    monad-schedule = {
+      url = "github:turion/monad-schedule";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs = inputs:


### PR DESCRIPTION
This prevents the [1000 instances of nixpkgs](https://zimbatm.com/notes/1000-instances-of-nixpkgs) problem.

I also drive-by re-enable flake checks. :angel: 