### PR TITLE
Add ListT implementation based on coalgebraic streams

### DIFF
--- a/automaton/automaton.cabal
+++ b/automaton/automaton.cabal
@@ -47,9 +47,11 @@ common opts
   default-extensions:
     Arrows
     DataKinds
+    DerivingStrategies
     FlexibleContexts
     FlexibleInstances
     ImportQualifiedPost
+    LambdaCase
     MultiParamTypeClasses
     NamedFieldPuns
     NoStarIsType
@@ -63,6 +65,7 @@ common opts
 library
   import: opts
   exposed-modules:
+    Control.Monad.Trans.List
     Data.Automaton
     Data.Automaton.Recursive
     Data.Automaton.Trans.Accum
@@ -96,6 +99,7 @@ test-suite automaton-test
     Automaton.Except
     Automaton.Trans.Accum
     Stream
+    Test.Control.Monad.Trans.List
 
   build-depends:
     QuickCheck >=2.14 && <2.16,

--- a/automaton/src/Control/Monad/Trans/List.hs
+++ b/automaton/src/Control/Monad/Trans/List.hs
@@ -1,0 +1,156 @@
+module Control.Monad.Trans.List where
+
+import Control.Applicative (Alternative (..))
+import Control.Monad (MonadPlus)
+import Control.Monad.Morph (MFunctor (..))
+import Control.Monad.Trans.Class (MonadTrans, lift)
+import Control.Monad.Trans.Except (ExceptT, runExceptT, throwE)
+import Data.Coerce (coerce)
+import Data.Functor ((<&>))
+import Data.Stream (StreamT (..))
+import Data.Stream.Except (StreamExcept (CoalgebraicExcept), mapOutput, runStreamExcept, stepInstant)
+import Data.Stream.Optimized (OptimizedStreamT (..))
+import Data.Stream.Optimized qualified as Optimized
+import Data.Stream.Result (Result (..))
+import Control.Selective (Selective (..), selectM)
+
+-- FIXME Is it cleverer to put OptimizedStreamT (ExceptT () m) a here, and use StreamExcept only where I need it?
+newtype ListT m a = ListT {getListT :: StreamExcept a m ()}
+
+runListT :: (Monad m) => ListT m a -> m [a]
+runListT = runListT' . Optimized.toStreamT . runStreamExcept . getListT
+  where
+    runListT' :: (Monad m) => StreamT (ExceptT () m) a -> m [a]
+    runListT' StreamT {state, step} = go state
+      where
+        go s = do
+          result <- runExceptT $ step s
+          case result of
+            Left () -> return []
+            Right (Result s' a) -> (a :) <$> go s'
+
+listT :: Monad m => [m a] -> ListT m a
+listT state = ListT $ CoalgebraicExcept $ Stateful StreamT
+  { state
+  , step = \case
+      [] -> throwE ()
+      (ma : mas) -> Result mas <$> lift ma
+  }
+
+-- FIXME Haddocks
+
+instance (Functor m) => Functor (ListT m) where
+  fmap = coerce mapOutput
+
+-- FIXME It's weird I have so many basic constructions in this module where I can't reuse other code.
+-- Probably there are some important utilities missing elsewhere
+
+instance (Monad m) => Applicative (ListT m) where
+  pure a =
+    ListT $
+      CoalgebraicExcept $
+        Stateful $
+          StreamT
+            { state = False
+            , step = \done -> if done then throwE () else pure $! Result True a
+            }
+
+  ListT fs <*> ListT as = ap (runStreamExcept fs) (runStreamExcept as)
+    where
+      ap (Stateful (StreamT fState0 fStep)) (Stateful (StreamT aState0 aStep)) =
+        ListT $
+          CoalgebraicExcept $
+            Stateful
+              StreamT
+                { -- FIXME strict datatype
+                  state = (fState0, aState0, Nothing)
+                , step
+                }
+        where
+          -- FIXME Maybe this would work with Applicative m as well if I unroll a bit?
+          step (fState, aState, Nothing) = do
+            Result fState' f <- fStep fState
+            step (fState', aState, Just f)
+          step (fState, aState, justF@(Just f)) = do
+            resultA <- lift $ runExceptT $ aStep aState
+            case resultA of
+              Left () -> step (fState, aState0, Nothing)
+              Right (Result aState' a) -> return $! Result (fState, aState', justF) $ f a
+      ap (Stateless mf) (Stateful (StreamT aState0 aStep)) =
+        ListT $
+          CoalgebraicExcept $
+            Stateful
+              StreamT
+                { state = aState0
+                , step = \aState -> do
+                    f <- mf
+                    Result aState' a <- aStep aState
+                    return $ Result aState' $ f a
+                }
+      ap (Stateful (StreamT fState0 fStep)) (Stateless ma) =
+        ListT $
+          CoalgebraicExcept $
+            Stateful
+              StreamT
+                { state = fState0
+                , step = \fState -> do
+                    Result fState' f <- fStep fState
+                    Result fState' . f <$> ma
+                }
+      ap (Stateless f) (Stateless a) = ListT $ CoalgebraicExcept $ Stateless $ f <*> a
+
+-- | This is just 'selectM', similar to the list instance
+instance Monad m => Selective (ListT m) where
+  select = selectM
+
+-- FIXME document performance
+instance (Monad m) => Monad (ListT m) where
+  -- FIXME Can't I pattern match on startingCont here to extract the state?
+  ListT startingCont >>= f = ListT $ go startingCont
+    where
+      go current = do
+        maybeResult <- lift $ stepInstant current
+        case maybeResult of
+          Left () -> return ()
+          Right (Result cont a) -> do
+            getListT $ f a
+            go cont
+
+instance (Monad m) => Alternative (ListT m) where
+  empty = ListT $ pure ()
+  ListT as1 <|> ListT as2 = ListT $ as1 >> as2
+
+instance (Monad m) => MonadPlus (ListT m)
+
+-- FIXME Unclear which Monoid instance I'd want. liftA2 (<>) or <|>?
+
+instance MonadTrans ListT where
+  lift ma =
+    ListT $
+      CoalgebraicExcept $
+        Stateful $
+          StreamT
+            { state = False
+            , step = \done -> if done then throwE () else Result True <$> lift ma
+            }
+
+instance MFunctor ListT where
+  hoist morph = ListT . hoist morph . getListT
+
+-- FIXME lift all mtl classes in separate package
+
+instance (Foldable m) => Foldable (ListT m) where
+  foldMap f ListT {getListT} = foldMap f $ runStreamExcept getListT
+
+instance (Traversable m) => Traversable (ListT m) where
+  traverse f ListT {getListT} = traverse f (runStreamExcept getListT) <&> ListT . CoalgebraicExcept
+
+-- iterListT :: (m [a] -> n a) -> ListT m a  -> n a
+-- iterListT morph = _
+
+stepListT :: (Monad m) => ListT m a -> m (Maybe (a, ListT m a))
+stepListT ListT {getListT} = do
+  result <- stepInstant getListT
+  return $ case result of
+    Left () -> Nothing
+    Right (Result cont a) -> Just (a, ListT cont)

--- a/automaton/src/Data/Stream.hs
+++ b/automaton/src/Data/Stream.hs
@@ -443,3 +443,10 @@ loop at runtime due to the coalgebraic encoding of the state.
 fixA :: (Applicative m) => StreamT m (a -> a) -> StreamT m a
 fixA StreamT {state, step} = fixStream (JointState state) $
   \stepA (JointState s ss) -> apResult <$> step s <*> stepA ss
+
+mmap :: Monad m => (a -> m b) -> StreamT m a -> StreamT m b
+mmap f StreamT {state, step} = StreamT {state, step = \s -> do
+  Result s' a <- step s
+  b <- f a
+  return $ Result s' b
+  }

--- a/automaton/src/Data/Stream.hs
+++ b/automaton/src/Data/Stream.hs
@@ -11,6 +11,7 @@ module Data.Stream where
 import Control.Applicative (Alternative (..), Applicative (..), liftA2)
 import Control.Monad ((<$!>))
 import Data.Bifunctor (bimap)
+import Data.Function ((&))
 import Data.Monoid (Ap (..))
 import Prelude hiding (Applicative (..))
 
@@ -115,6 +116,14 @@ instance (Applicative m) => Applicative (StreamT m) where
   StreamT stateF0 stepF <*> StreamT stateA0 stepA =
     StreamT (JointState stateF0 stateA0) (\(JointState stateF stateA) -> apResult <$> stepF stateF <*> stepA stateA)
   {-# INLINE (<*>) #-}
+
+instance (Foldable m) => Foldable (StreamT m) where
+  foldMap f StreamT {state, step} = go state
+    where
+      go s = step s & foldMap (\(Result s' a) -> f a <> go s')
+
+instance (Traversable m, Functor m) => Traversable (StreamT m) where
+  traverse f = fmap fromRecursive . traverse f . toRecursive
 
 deriving via Ap (StreamT m) a instance (Applicative m, Num a) => Num (StreamT m a)
 

--- a/automaton/src/Data/Stream/Optimized.hs
+++ b/automaton/src/Data/Stream/Optimized.hs
@@ -222,3 +222,7 @@ applyExcept streamF streamA = Stateful $ StreamT.applyExcept (toStreamT streamF)
 selectExcept :: (Monad m) => OptimizedStreamT (ExceptT (Either e1 e2) m) a -> OptimizedStreamT (ExceptT (e1 -> e2) m) a -> OptimizedStreamT (ExceptT e2 m) a
 selectExcept streamE streamF = Stateful $ StreamT.selectExcept (toStreamT streamE) (toStreamT streamF)
 {-# INLINE selectExcept #-}
+
+mmap :: Monad m => (a -> m b) -> OptimizedStreamT m a -> OptimizedStreamT m b
+mmap f (Stateful stream) = Stateful $ StreamT.mmap f stream
+mmap f (Stateless g) = Stateless $ g >>= f

--- a/automaton/src/Data/Stream/Optimized.hs
+++ b/automaton/src/Data/Stream/Optimized.hs
@@ -1,4 +1,6 @@
+{-# LANGUAGE DeriveFoldable #-}
 {-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DeriveTraversable #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE StandaloneDeriving #-}
@@ -51,7 +53,7 @@ data OptimizedStreamT m a
     Stateful (StreamT m a)
   | -- | A stateless stream is simply an action in a monad which is performed repetitively.
     Stateless (m a)
-  deriving (Functor)
+  deriving (Functor, Foldable, Traversable)
 
 {- | Remove the optimization layer.
 

--- a/automaton/src/Data/Stream/Recursive.hs
+++ b/automaton/src/Data/Stream/Recursive.hs
@@ -61,3 +61,11 @@ instance (Alternative m) => Alternative (Recursive m) where
   empty = constM empty
 
   Recursive ma1 <|> Recursive ma2 = Recursive $ ma1 <|> ma2
+
+instance (Foldable m) => Foldable (Recursive m) where
+  foldMap f Recursive {getRecursive} = foldMap (\(Result Recursive a) -> f a <> foldMap f Recursive) getRecursive
+
+instance (Traversable m) => Traversable (Recursive m) where
+  traverse f = go
+    where
+      go Recursive {getRecursive} = (getRecursive & traverse (\(Result cont a) -> flip Result <$> f a <*> go cont)) <&> Recursive

--- a/automaton/src/Data/Stream/Recursive.hs
+++ b/automaton/src/Data/Stream/Recursive.hs
@@ -69,3 +69,11 @@ instance (Traversable m) => Traversable (Recursive m) where
   traverse f = go
     where
       go Recursive {getRecursive} = (getRecursive & traverse (\(Result cont a) -> flip Result <$> f a <*> go cont)) <&> Recursive
+
+-- FIXME define for automaton as well
+-- FIXME go trick
+mmap :: (Monad m) => (a -> m b) -> Recursive m a -> Recursive m b
+mmap f Recursive {getRecursive} = Recursive $ do
+  Result Recursive a <- getRecursive
+  b <- f a
+  return $ Result (mmap f Recursive) b

--- a/automaton/test/Main.hs
+++ b/automaton/test/Main.hs
@@ -5,6 +5,7 @@ import Test.Tasty
 
 -- automaton
 import Automaton
+import Test.Control.Monad.Trans.List
 import Stream
 
 main =
@@ -12,5 +13,6 @@ main =
     testGroup
       "Main"
       [ Automaton.tests
+      , Test.Control.Monad.Trans.List.tests
       , Stream.tests
       ]

--- a/automaton/test/Test/Control/Monad/Trans/List.hs
+++ b/automaton/test/Test/Control/Monad/Trans/List.hs
@@ -1,0 +1,89 @@
+{-# LANGUAGE StandaloneDeriving #-}
+
+module Test.Control.Monad.Trans.List where -- FIXME should I maybe move all test files in that hierarchy?
+
+-- base
+import Control.Applicative (Alternative ((<|>)))
+import Data.Bifunctor (first)
+import Data.Functor.Identity (Identity (runIdentity))
+
+-- transformers
+import Control.Monad.Trans.Class (lift)
+import Control.Monad.Trans.Writer.Lazy (Writer, WriterT (..), tell) -- Using lazy writer here so I can deal with lazy infinite streams
+
+-- tasty
+import Test.Tasty (testGroup)
+
+-- tasty-hunit
+import Test.Tasty.HUnit (testCase, (@?=))
+
+-- automaton
+import Control.Monad.Trans.List
+import Data.Functor.Classes (Eq1, Show1)
+import Data.Stream (unfold_)
+import Data.Stream.Except (StreamExcept (CoalgebraicExcept), stepInstant)
+import Data.Stream.Optimized (OptimizedStreamT (..), mmap)
+import Data.Stream.Result (Result (..))
+
+type M = ListT (Writer [String])
+
+run :: M a -> ([a], [String])
+run = runIdentity . runWriterT . runListT
+
+{- HLINT ignore "Use newtype instead of data" -}
+data RecursiveListT m a = RecursiveListT (m (Maybe (a, RecursiveListT m a)))
+
+deriving instance (Eq1 m, Eq a) => Eq (RecursiveListT m a)
+deriving instance (Show1 m, Show a) => Show (RecursiveListT m a)
+
+recursive :: (Monad m) => ListT m a -> RecursiveListT m a
+recursive = recursive' . getListT
+  where
+    recursive' mas = RecursiveListT $ do
+      result <- stepInstant mas
+      pure $ case result of
+        Left () -> Nothing
+        Right (Result mas' a) -> Just (a, recursive' mas')
+
+sample :: M Int
+sample = listT [pure 0, tell ["Hi"] >> pure 1, tell ["World"] >> pure 2] <|> pure 3 <|> (lift (tell ["!"]) >> pure 4)
+
+sampleNumbers = [0, 1, 2, 3, 4]
+sampleLog = ["Hi", "World", "!"]
+
+{- HLINT ignore tests "Redundant <$>" -}
+{- HLINT ignore tests "Redundant pure" -}
+{- HLINT ignore tests "Use $>" -}
+{- HLINT ignore tests "Functor law" -}
+tests =
+  testGroup
+    "Control.Monad.Trans.List"
+    [ testGroup
+        "runListT"
+        [ testCase "Empty" $ run (listT []) @?= ([] :: [Int], [])
+        , testCase "Single element" $ run (listT [pure 3]) @?= ([3], [])
+        , testCase "sample" $ run sample @?= ([0, 1, 2, 3, 4], ["Hi", "World", "!"])
+        ]
+    , testCase "listT" $ run (listT [pure 0, tell ["Hi"] >> pure 1, tell ["World"] >> pure 2]) @?= ([0, 1, 2], ["Hi", "World"])
+    , testGroup
+        "Functor"
+        [ testCase "fmap" $ run ((2 *) <$> sample) @?= first (fmap (2 *)) (run sample)
+        , testCase "fmap law" $ recursive ((2 *) <$> (2 *) <$> sample) @?= recursive ((4 *) <$> sample)
+        ]
+    , testGroup
+        "Applicative"
+        [ testCase "pure" $ run (pure 3 :: M Int) @?= ([3], [])
+        , testGroup
+            "<*>"
+            [ testCase "pure pure" $ recursive (pure 3 *> pure 4) @?= recursive (pure 4 :: M Int)
+            , testCase "pure fmap" $ recursive ((+) <$> pure 1 <*> pure 2) @?= recursive (pure 3 :: M Int)
+            , testCase "pure sample" $ recursive ((+) <$> sample <*> pure 1) @?= recursive ((+) <$> pure 1 <*> sample)
+            , testCase "sample sample" $ run ((+) <$> sample <*> sample) @?= ((+) <$> sampleNumbers <*> sampleNumbers, [])
+            ]
+        ]
+    , testGroup
+        "Infinite lists"
+        [ testCase "listT" $ let (ns, logs) = run $ listT $ (\n -> tell [show n] >> pure n) <$> [0 ..] in (take 5 ns, take 5 logs) @?= ([1, 2, 3, 4, 5], ["0", "1", "2", "3", "4", "5"])
+        [ testCase "infinite stream" $ let (ns, logs) = run $ ListT $ CoalgebraicExcept $ mmap (\n -> lift (tell [show n]) >> pure n) $ Stateful $ unfold_ 0 (+ 1) in take 5 ns @?= ([1, 2, 3, 4, 5], ["1", "2", "3", "4", "5"])
+        ]
+    ]


### PR DESCRIPTION
* [ ] Should this be a separate package?
* [ ] Test suite should import some established [`ListT`](https://hackage.haskell.org/package/list-transformer), and propcheck (https://hackage.haskell.org/package/falsify) whether semantics agree
* [ ] Maybe a small benchmark comparing established and this `ListT`