### PR TITLE
time-domain: add epoch and zero duration

### DIFF
--- a/time-domain/src/Data/TimeDomain.hs
+++ b/time-domain/src/Data/TimeDomain.hs
@@ -55,10 +55,15 @@ class (TimeDifference (Diff time)) => TimeDomain time where
 
 Expected laws:
 
+* @dt `add` 'zero' = dt@ and @dt `difference` 'zero' = dt@
 * `add` is commutative and associative
 * @(dt1 `difference` dt2) `add` dt2 = dt1@
 -}
 class TimeDifference d where
+  -- | The zero duration, i.e. no time has passed.
+  --   Additive identity for 'difference' and 'add'.
+  zero :: d
+
   -- | Calculate the difference between two durations,
   --   compatibly with 'diffTime'.
   difference :: d -> d -> d
@@ -74,6 +79,7 @@ instance TimeDomain UTCTime where
   addTime = flip $ addUTCTime . realToFrac
 
 instance TimeDifference Double where
+  zero = 0
   difference = (-)
   add = (+)
 
@@ -84,6 +90,7 @@ instance TimeDomain Double where
   addTime = (+)
 
 instance TimeDifference Float where
+  zero = 0
   difference = (-)
   add = (+)
 
@@ -94,6 +101,7 @@ instance TimeDomain Float where
   addTime = (+)
 
 instance TimeDifference Integer where
+  zero = 0
   difference = (-)
   add = (+)
 
@@ -104,6 +112,7 @@ instance TimeDomain Integer where
   addTime = (+)
 
 instance TimeDifference () where
+  zero = ()
   difference _ _ = ()
   add _ _ = ()
 
@@ -118,6 +127,7 @@ newtype NumTimeDomain a = NumTimeDomain {fromNumTimeDomain :: a}
   deriving (Num)
 
 instance (Num a) => TimeDifference (NumTimeDomain a) where
+  zero = 0
   difference = (-)
   add = (+)
 

--- a/time-domain/src/Data/TimeDomain.hs
+++ b/time-domain/src/Data/TimeDomain.hs
@@ -17,6 +17,7 @@ where
 
 -- time
 import Data.Time.Clock (UTCTime, addUTCTime, diffUTCTime)
+import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
 
 {- |
 A time domain is an affine space representing a notion of time,
@@ -31,6 +32,14 @@ Expected laws:
 class (TimeDifference (Diff time)) => TimeDomain time where
   -- | The type of differences or durations between two timestamps
   type Diff time
+
+  -- | The origin of the time domain.
+  --
+  --   All timestamps can be understood as durations relative to this reference point.
+  --
+  --   For example, 'UTCTime' uses the Unix epoch (1970-01-01 00:00:00 UTC),
+  --   while numeric instances use @0@.
+  epoch :: time
 
   -- | Compute the difference between two timestamps.
   --
@@ -60,6 +69,7 @@ class TimeDifference d where
 -- | Differences between 'UTCTime's are measured in seconds.
 instance TimeDomain UTCTime where
   type Diff UTCTime = Double
+  epoch = posixSecondsToUTCTime 0
   diffTime t1 t2 = realToFrac $ diffUTCTime t1 t2
   addTime = flip $ addUTCTime . realToFrac
 
@@ -69,6 +79,7 @@ instance TimeDifference Double where
 
 instance TimeDomain Double where
   type Diff Double = Double
+  epoch = 0
   diffTime = (-)
   addTime = (+)
 
@@ -78,6 +89,7 @@ instance TimeDifference Float where
 
 instance TimeDomain Float where
   type Diff Float = Float
+  epoch = 0
   diffTime = (-)
   addTime = (+)
 
@@ -87,6 +99,7 @@ instance TimeDifference Integer where
 
 instance TimeDomain Integer where
   type Diff Integer = Integer
+  epoch = 0
   diffTime = (-)
   addTime = (+)
 
@@ -96,6 +109,7 @@ instance TimeDifference () where
 
 instance TimeDomain () where
   type Diff () = ()
+  epoch = ()
   diffTime _ _ = ()
   addTime _ _ = ()
 
@@ -109,5 +123,6 @@ instance (Num a) => TimeDifference (NumTimeDomain a) where
 
 instance (Num a) => TimeDomain (NumTimeDomain a) where
   type Diff (NumTimeDomain a) = NumTimeDomain a
+  epoch = 0
   diffTime = (-)
   addTime = (+)


### PR DESCRIPTION
When writing code that uses `TimeDomain time`, I often find myself having to add additional constraints on `time` or `Diff time` in order to be able to express "initial accumulator value" or "duration of an empty sequence of timestamps".

One such trick is to declare `Num time` and use `0`, or declare `Monoid time` and use `mempty`.

Such tricks are not satisfying.

This PR makes two assertions, that are hopefully not too controversial:
- Every time domain has a well-defined, canonical origin / reference value
- Every set of time differences has an additive identity for `add` and `difference`