### PR TITLE
Render haddock code blocks as blocks, not inline

### DIFF
--- a/automaton/src/Data/Automaton.hs
+++ b/automaton/src/Data/Automaton.hs
@@ -78,6 +78,7 @@ and related type classes.
 This allows for more ways of creating or composing them.
 
 For example, you can sequentially and parallely compose two automata:
+
 @
 automaton1 :: Automaton m a b
 automaton2 :: Automaton m b c
@@ -88,6 +89,7 @@ sequentially = automaton1 >>> automaton2
 inParallel :: Automaton m (a, b) (b, c)
 inParallel = automaton1 *** automaton2
 @
+
 In sequential composition, the output of the first automaton is passed as input to the second one.
 In parallel composition, both automata receive input simulataneously and process it independently.
 

--- a/automaton/src/Data/Automaton/Trans/Except.hs
+++ b/automaton/src/Data/Automaton/Trans/Except.hs
@@ -183,6 +183,7 @@ This type is useful because it is a monad in the /exception type/ @e@.
     function, which can throw exceptions in a different type.
 
 Consider this example:
+
 @
 automaton :: AutomatonExcept a b m e1
 f :: e1 -> AutomatonExcept a b m e2

--- a/automaton/src/Data/Stream.hs
+++ b/automaton/src/Data/Stream.hs
@@ -69,9 +69,11 @@ while the coalgebraic encoding knows its state only at runtime.
 
 This performance gain comes at a peculiar cost:
 Recursive definitions /of/ streams are not possible, e.g. an equation like:
+
 @
   fixA stream = stream <*> fixA stream
 @
+
 This is impossible since the stream under definition itself appears in the definition body,
 and thus the internal /state type/ would be recursively defined, which GHC doesn't allow:
 Type level recursion is not supported in existential types.
@@ -422,10 +424,12 @@ instance (Align m) => Align (StreamT m) where
 
 If you want to define a stream recursively, this is not possible directly.
 For example, consider this definition:
+
 @
 loops :: Monad m => StreamT m [Int]
 loops = (:) <$> unfold_ 0 (+ 1) <*> loops
 @
+
 The defined value @loops@ contains itself in its definition.
 This means that the internal state type of @loops@ must itself be recursively defined.
 But GHC cannot do this automatically, because type level and value level are separate.

--- a/rhine/src/FRP/Rhine/ClSF/Util.hs
+++ b/rhine/src/FRP/Rhine/ClSF/Util.hs
@@ -45,6 +45,7 @@ timeInfo = constM ask
 
 {- | Utility to apply functions to the current 'TimeInfo',
 such as record selectors:
+
 @
 printAbsoluteTime :: ClSF IO cl () ()
 printAbsoluteTime = timeInfoOf absolute >>> arrMCl print


### PR DESCRIPTION
Insert blank lines around the opening and closing `@` so that the `@...@` code renders as a block. Without them Haddock merges it into the adjacent paragraph, rendering it inline or even showing the literal `@`.