### PR TITLE
List-T

### DIFF
--- a/automaton/automaton.cabal
+++ b/automaton/automaton.cabal
@@ -90,6 +90,7 @@ library
     Data.Automaton.Trans.Accum
     Data.Automaton.Trans.Changeset
     Data.Automaton.Trans.Except
+    Data.Automaton.Trans.List
     Data.Automaton.Trans.Maybe
     Data.Automaton.Trans.RWS
     Data.Automaton.Trans.Random

--- a/automaton/automaton.cabal
+++ b/automaton/automaton.cabal
@@ -28,12 +28,12 @@ source-repository this
 
 common opts
   build-depends:
+    List ^>=0.6,
     MonadRandom >=0.5,
     base >=4.18 && <4.22,
     changeset ^>=0.2,
     containers >=0.5,
     free >=5.1,
-    list-t ^>=1.0,
     mmorph ^>=1.2,
     mtl >=2.2 && <2.4,
     profunctors ^>=5.6,

--- a/automaton/automaton.cabal
+++ b/automaton/automaton.cabal
@@ -33,6 +33,7 @@ common opts
     changeset ^>=0.2,
     containers >=0.5,
     free >=5.1,
+    list-t ^>=1.0,
     mmorph ^>=1.2,
     mtl >=2.2 && <2.4,
     profunctors ^>=5.6,

--- a/automaton/automaton.cabal
+++ b/automaton/automaton.cabal
@@ -28,12 +28,12 @@ source-repository this
 
 common opts
   build-depends:
-    List ^>=0.6,
     MonadRandom >=0.5,
     base >=4.18 && <4.22,
     changeset ^>=0.2,
     containers >=0.5,
     free >=5.1,
+    list-transformer ^>=1.1,
     mmorph ^>=1.2,
     mtl >=2.2 && <2.4,
     profunctors ^>=5.6,

--- a/automaton/automaton.cabal
+++ b/automaton/automaton.cabal
@@ -123,6 +123,7 @@ test-suite automaton-test
     Automaton.Schedule
     Automaton.Trans.Accum
     Automaton.Trans.Changeset
+    Automaton.Trans.List
     Stream
 
   build-depends:

--- a/automaton/src/Data/Automaton.hs
+++ b/automaton/src/Data/Automaton.hs
@@ -49,7 +49,7 @@ import Data.These (these)
 import Witherable (Filterable (..), Witherable (wither))
 
 -- list-transformer
-import List.Transformer (ListT (..), Step (..), fold)
+import List.Transformer (ListT, fold, select)
 
 -- semialign
 import Data.Semialign (Align (..), Semialign (..))
@@ -620,14 +620,10 @@ handleEffect send interpret = handleAutomaton $ StreamT.handleEffect (lift . sen
 
 -- | Execute and collect all branches of a nondeterministic automaton.
 handleListT :: (Monad m) => Automaton (ListT m) a b -> Automaton m a [b]
-handleListT = handleEffect fromList toList
+handleListT = handleEffect select toList
   where
-    fromList :: (Monad m) => [a] -> ListT m a
-    fromList = foldr cons empty
     toList :: (Monad m) => ListT m a -> m [a]
-    toList = fmap reverse . fold (flip (:)) [] id
-    cons :: (Monad m) => a -> ListT m a -> ListT m a
-    cons x xs = ListT $ return $ Cons x xs
+    toList = fold (flip (:)) [] reverse
 
 -- * Examples
 

--- a/automaton/src/Data/Automaton.hs
+++ b/automaton/src/Data/Automaton.hs
@@ -48,9 +48,8 @@ import Data.These (these)
 -- witherable
 import Witherable (Filterable (..), Witherable (wither))
 
--- List
-import Control.Monad.ListT (ListT)
-import Data.List.Class (fromList, toList)
+-- list-transformer
+import List.Transformer (ListT (..), Step (..), fold)
 
 -- semialign
 import Data.Semialign (Align (..), Semialign (..))
@@ -622,6 +621,13 @@ handleEffect send interpret = handleAutomaton $ StreamT.handleEffect (lift . sen
 -- | Execute and collect all branches of a nondeterministic automaton.
 handleListT :: (Monad m) => Automaton (ListT m) a b -> Automaton m a [b]
 handleListT = handleEffect fromList toList
+  where
+    fromList :: (Monad m) => [a] -> ListT m a
+    fromList = foldr cons empty
+    toList :: (Monad m) => ListT m a -> m [a]
+    toList = fmap reverse . fold (flip (:)) [] id
+    cons :: (Monad m) => a -> ListT m a -> ListT m a
+    cons x xs = ListT $ return $ Cons x xs
 
 -- * Examples
 

--- a/automaton/src/Data/Automaton.hs
+++ b/automaton/src/Data/Automaton.hs
@@ -457,6 +457,10 @@ instance (Monad m) => Cochoice (Automaton m) where
 
 -- ** Traversing automata
 
+-- | Apply an 'Automaton' to every input.
+mapS :: (Monad m) => Automaton m a b -> Automaton m [a] [b]
+mapS = traverse'
+
 -- | Only step the automaton if the input is 'Just'.
 mapMaybeS :: (Monad m) => Automaton m a b -> Automaton m (Maybe a) (Maybe b)
 mapMaybeS = traverse'

--- a/automaton/src/Data/Automaton.hs
+++ b/automaton/src/Data/Automaton.hs
@@ -48,6 +48,9 @@ import Data.These (these)
 -- witherable
 import Witherable (Filterable (..), Witherable (wither))
 
+-- list-t
+import ListT (ListT, fromFoldable, toList)
+
 -- semialign
 import Data.Semialign (Align (..), Semialign (..))
 
@@ -614,6 +617,10 @@ handleEffect ::
   Automaton eff a b ->
   Automaton m a (sig b)
 handleEffect send interpret = handleAutomaton $ StreamT.handleEffect (lift . send) (\raction -> ReaderT $ \a -> interpret $ runReaderT raction a)
+
+-- | Execute and collect all branches of a nondeterministic automaton.
+handleListT :: (Monad m) => Automaton (ListT m) a b -> Automaton m a [b]
+handleListT = handleEffect fromFoldable toList
 
 -- * Examples
 

--- a/automaton/src/Data/Automaton.hs
+++ b/automaton/src/Data/Automaton.hs
@@ -48,8 +48,9 @@ import Data.These (these)
 -- witherable
 import Witherable (Filterable (..), Witherable (wither))
 
--- list-t
-import ListT (ListT, fromFoldable, toList)
+-- List
+import Control.Monad.ListT (ListT)
+import Data.List.Class (fromList, toList)
 
 -- semialign
 import Data.Semialign (Align (..), Semialign (..))
@@ -620,7 +621,7 @@ handleEffect send interpret = handleAutomaton $ StreamT.handleEffect (lift . sen
 
 -- | Execute and collect all branches of a nondeterministic automaton.
 handleListT :: (Monad m) => Automaton (ListT m) a b -> Automaton m a [b]
-handleListT = handleEffect fromFoldable toList
+handleListT = handleEffect fromList toList
 
 -- * Examples
 

--- a/automaton/src/Data/Automaton/Trans/List.hs
+++ b/automaton/src/Data/Automaton/Trans/List.hs
@@ -7,7 +7,7 @@ module Data.Automaton.Trans.List (
   module List.Transformer,
   widthFirst,
   sequenceS,
-  fromList,
+  fromFoldable,
   toList,
 )
 where
@@ -33,15 +33,12 @@ sequenceS :: (Monad m) => [Automaton m a b] -> Automaton (ListT m) a b
 sequenceS = asum . fmap liftS
 {-# INLINEABLE sequenceS #-}
 
--- | Construct from a list.
-fromList :: (Monad m) => [a] -> ListT m a
-fromList = foldr cons empty
-{-# INLINEABLE fromList #-}
+-- | Construct from an arbitrary Foldable (a wrapper around 'select').
+fromFoldable :: (Monad m, Foldable f) => f a -> ListT m a
+fromFoldable = select
+{-# INLINEABLE fromFoldable #-}
 
 -- | Fold into a list.
 toList :: (Monad m) => ListT m a -> m [a]
-toList = fmap reverse . fold (flip (:)) [] id
+toList = fold (flip (:)) [] reverse
 {-# INLINEABLE toList #-}
-
-cons :: (Monad m) => a -> ListT m a -> ListT m a
-cons x xs = ListT $ pure $ Cons x xs

--- a/automaton/src/Data/Automaton/Trans/List.hs
+++ b/automaton/src/Data/Automaton/Trans/List.hs
@@ -4,18 +4,19 @@
 each input, or none. This enables dynamic spawning and stopping of automata.
 -}
 module Data.Automaton.Trans.List (
-  module Data.List.Class,
+  module List.Transformer,
   widthFirst,
   sequenceS,
+  fromList,
+  toList,
 )
 where
 
 -- base
 import Control.Applicative (asum)
 
--- List
-import Control.Monad.ListT (ListT)
-import Data.List.Class
+-- list-transformer
+import List.Transformer
 
 -- automaton
 import Data.Automaton (Automaton, handleListT, liftS)
@@ -29,3 +30,14 @@ widthFirst = handleListT
 -- | Build an 'Automaton' in the 'ListT' transformer by broadcasting the input to each automaton in a given list.
 sequenceS :: (Monad m) => [Automaton m a b] -> Automaton (ListT m) a b
 sequenceS = asum . fmap liftS
+
+-- | Construct from a list.
+fromList :: (Monad m) => [a] -> ListT m a
+fromList = foldr cons empty
+
+-- | Fold into a list.
+toList :: (Monad m) => ListT m a -> m [a]
+toList = fmap reverse . fold (flip (:)) [] id
+
+cons :: (Monad m) => a -> ListT m a -> ListT m a
+cons x xs = ListT $ pure $ Cons x xs

--- a/automaton/src/Data/Automaton/Trans/List.hs
+++ b/automaton/src/Data/Automaton/Trans/List.hs
@@ -1,0 +1,57 @@
+{- | Handle a global 'ListT' layer in an 'Automaton'.
+
+'Automaton's in the 'ListT' transformer can produce multiple outputs for
+each input, or none. This enables dynamic spawning and stopping of automata.
+-}
+module Data.Automaton.Trans.List (
+  module ListT,
+  widthFirst,
+  sequenceS,
+  mapAutomaton,
+)
+where
+
+-- transformers
+import Control.Monad.Trans.Class (lift)
+import Control.Monad.Trans.Reader (runReaderT)
+
+-- list-t
+import ListT hiding (traverse, unfoldM)
+
+-- automaton
+import Data.Automaton (Automaton (..), getAutomaton, traverseS, unfoldM)
+import Data.Stream.Optimized (stepOptimizedStream)
+import Data.Stream.Result (Result (..))
+
+-- base
+import Data.List (singleton)
+
+{- | Run an 'Automaton' in the 'ListT' transformer by applying the input to
+each automaton in the list transformer and concatenating the outputs.
+-}
+widthFirst :: (Functor m, Monad m) => Automaton (ListT m) a b -> Automaton m a [b]
+widthFirst = flip unfoldM step . singleton
+  where
+    step a as = do
+      results <- concat <$> traverse (stepOne a) as
+      let (bs, as') = unzip results
+      pure $ Result as' bs
+    stepOne a auto =
+      toList $
+        (\(Result auto' b) -> (b, Automaton auto'))
+          <$> runReaderT (stepOptimizedStream (getAutomaton auto)) a
+
+-- | Build an 'Automaton' in the 'ListT' transformer by broadcasting the input to each automaton in a given list.
+sequenceS :: (Monad m) => [Automaton m a b] -> Automaton (ListT m) a b
+sequenceS = flip unfoldM step
+  where
+    step a auto = do
+      results <- lift $ traverse (stepOne a) auto
+      fromFoldable results
+    stepOne a auto = do
+      Result auto' b <- runReaderT (stepOptimizedStream (getAutomaton auto)) a
+      pure $ Result [Automaton auto'] b
+
+-- | Apply an 'Automaton' to every input.
+mapAutomaton :: (Monad m) => Automaton m a b -> Automaton m [a] [b]
+mapAutomaton = traverseS

--- a/automaton/src/Data/Automaton/Trans/List.hs
+++ b/automaton/src/Data/Automaton/Trans/List.hs
@@ -26,18 +26,22 @@ each automaton in the list transformer and concatenating the outputs.
 -}
 widthFirst :: (Monad m) => Automaton (ListT m) a b -> Automaton m a [b]
 widthFirst = handleListT
+{-# INLINEABLE widthFirst #-}
 
 -- | Build an 'Automaton' in the 'ListT' transformer by broadcasting the input to each automaton in a given list.
 sequenceS :: (Monad m) => [Automaton m a b] -> Automaton (ListT m) a b
 sequenceS = asum . fmap liftS
+{-# INLINEABLE sequenceS #-}
 
 -- | Construct from a list.
 fromList :: (Monad m) => [a] -> ListT m a
 fromList = foldr cons empty
+{-# INLINEABLE fromList #-}
 
 -- | Fold into a list.
 toList :: (Monad m) => ListT m a -> m [a]
 toList = fmap reverse . fold (flip (:)) [] id
+{-# INLINEABLE toList #-}
 
 cons :: (Monad m) => a -> ListT m a -> ListT m a
 cons x xs = ListT $ pure $ Cons x xs

--- a/automaton/src/Data/Automaton/Trans/List.hs
+++ b/automaton/src/Data/Automaton/Trans/List.hs
@@ -7,7 +7,6 @@ module Data.Automaton.Trans.List (
   module ListT,
   widthFirst,
   sequenceS,
-  mapAutomaton,
 )
 where
 
@@ -19,7 +18,7 @@ import Control.Monad.Trans.Reader (runReaderT)
 import ListT hiding (traverse, unfoldM)
 
 -- automaton
-import Data.Automaton (Automaton (..), getAutomaton, traverseS, unfoldM)
+import Data.Automaton (Automaton (..), getAutomaton, unfoldM)
 import Data.Stream.Optimized (stepOptimizedStream)
 import Data.Stream.Result (Result (..))
 
@@ -51,7 +50,3 @@ sequenceS = flip unfoldM step
     stepOne a auto = do
       Result auto' b <- runReaderT (stepOptimizedStream (getAutomaton auto)) a
       pure $ Result [Automaton auto'] b
-
--- | Apply an 'Automaton' to every input.
-mapAutomaton :: (Monad m) => Automaton m a b -> Automaton m [a] [b]
-mapAutomaton = traverseS

--- a/automaton/src/Data/Automaton/Trans/List.hs
+++ b/automaton/src/Data/Automaton/Trans/List.hs
@@ -10,17 +10,14 @@ module Data.Automaton.Trans.List (
 )
 where
 
--- transformers
-import Control.Monad.Trans.Class (lift)
-import Control.Monad.Trans.Reader (runReaderT)
+-- base
+import Control.Applicative (asum)
 
 -- list-t
-import ListT hiding (traverse, unfoldM)
+import ListT
 
 -- automaton
-import Data.Automaton (Automaton (..), getAutomaton, handleListT, unfoldM)
-import Data.Stream.Optimized (stepOptimizedStream)
-import Data.Stream.Result (Result (..))
+import Data.Automaton (Automaton, handleListT, liftS)
 
 {- | Run an 'Automaton' in the 'ListT' transformer by applying the input to
 each automaton in the list transformer and concatenating the outputs.
@@ -30,11 +27,4 @@ widthFirst = handleListT
 
 -- | Build an 'Automaton' in the 'ListT' transformer by broadcasting the input to each automaton in a given list.
 sequenceS :: (Monad m) => [Automaton m a b] -> Automaton (ListT m) a b
-sequenceS = flip unfoldM step
-  where
-    step a auto = do
-      results <- lift $ traverse (stepOne a) auto
-      fromFoldable results
-    stepOne a auto = do
-      Result auto' b <- runReaderT (stepOptimizedStream (getAutomaton auto)) a
-      pure $ Result [Automaton auto'] b
+sequenceS = asum . fmap liftS

--- a/automaton/src/Data/Automaton/Trans/List.hs
+++ b/automaton/src/Data/Automaton/Trans/List.hs
@@ -4,7 +4,7 @@
 each input, or none. This enables dynamic spawning and stopping of automata.
 -}
 module Data.Automaton.Trans.List (
-  module ListT,
+  module Data.List.Class,
   widthFirst,
   sequenceS,
 )
@@ -13,8 +13,9 @@ where
 -- base
 import Control.Applicative (asum)
 
--- list-t
-import ListT
+-- List
+import Control.Monad.ListT (ListT)
+import Data.List.Class
 
 -- automaton
 import Data.Automaton (Automaton, handleListT, liftS)

--- a/automaton/src/Data/Automaton/Trans/List.hs
+++ b/automaton/src/Data/Automaton/Trans/List.hs
@@ -18,27 +18,15 @@ import Control.Monad.Trans.Reader (runReaderT)
 import ListT hiding (traverse, unfoldM)
 
 -- automaton
-import Data.Automaton (Automaton (..), getAutomaton, unfoldM)
+import Data.Automaton (Automaton (..), getAutomaton, handleListT, unfoldM)
 import Data.Stream.Optimized (stepOptimizedStream)
 import Data.Stream.Result (Result (..))
-
--- base
-import Data.List (singleton)
 
 {- | Run an 'Automaton' in the 'ListT' transformer by applying the input to
 each automaton in the list transformer and concatenating the outputs.
 -}
-widthFirst :: (Functor m, Monad m) => Automaton (ListT m) a b -> Automaton m a [b]
-widthFirst = flip unfoldM step . singleton
-  where
-    step a as = do
-      results <- concat <$> traverse (stepOne a) as
-      let (bs, as') = unzip results
-      pure $ Result as' bs
-    stepOne a auto =
-      toList $
-        (\(Result auto' b) -> (b, Automaton auto'))
-          <$> runReaderT (stepOptimizedStream (getAutomaton auto)) a
+widthFirst :: (Monad m) => Automaton (ListT m) a b -> Automaton m a [b]
+widthFirst = handleListT
 
 -- | Build an 'Automaton' in the 'ListT' transformer by broadcasting the input to each automaton in a given list.
 sequenceS :: (Monad m) => [Automaton m a b] -> Automaton (ListT m) a b

--- a/automaton/src/Data/Stream.hs
+++ b/automaton/src/Data/Stream.hs
@@ -6,7 +6,7 @@ module Data.Stream where
 import Control.Applicative (Alternative (..), Applicative (..), liftA2)
 import Control.Monad ((<$!>))
 import Data.Bifunctor (bimap)
-import Data.Foldable (Foldable (..))
+import Data.Foldable (Foldable (toList))
 import Data.Function ((&))
 import Data.Functor ((<&>))
 import Data.Monoid (Ap (..))
@@ -20,9 +20,8 @@ import Control.Monad.Trans.Maybe (MaybeT (..))
 import Control.Monad.Trans.Reader (ReaderT (..))
 import Control.Monad.Trans.Writer (WriterT (runWriterT), writer)
 
--- List
-import Control.Monad.ListT (ListT)
-import Data.List.Class (fromList, toList)
+-- list-transformer
+import List.Transformer (ListT (..), Step (..), fold)
 
 -- mmorph
 import Control.Monad.Morph (MFunctor (hoist))
@@ -583,3 +582,10 @@ handleMaybeT = handleEffect (MaybeT . pure) runMaybeT
 -- | Execute and collect all branches of a nondeterministic stream.
 handleListT :: (Monad m) => StreamT (ListT m) a -> StreamT m [a]
 handleListT = handleEffect fromList toList
+  where
+    fromList :: (Monad m) => [a] -> ListT m a
+    fromList = foldr cons empty
+    toList :: (Monad m) => ListT m a -> m [a]
+    toList = fmap reverse . fold (flip (:)) [] id
+    cons :: (Monad m) => a -> ListT m a -> ListT m a
+    cons x xs = ListT $ pure $ Cons x xs

--- a/automaton/src/Data/Stream.hs
+++ b/automaton/src/Data/Stream.hs
@@ -21,7 +21,8 @@ import Control.Monad.Trans.Reader (ReaderT (..))
 import Control.Monad.Trans.Writer (WriterT (runWriterT), writer)
 
 -- list-transformer
-import List.Transformer (ListT (..), Step (..), fold)
+import List.Transformer (ListT, fold)
+import List.Transformer qualified as ListT (select)
 
 -- mmorph
 import Control.Monad.Morph (MFunctor (hoist))
@@ -581,11 +582,7 @@ handleMaybeT = handleEffect (MaybeT . pure) runMaybeT
 
 -- | Execute and collect all branches of a nondeterministic stream.
 handleListT :: (Monad m) => StreamT (ListT m) a -> StreamT m [a]
-handleListT = handleEffect fromList toList
+handleListT = handleEffect ListT.select toList
   where
-    fromList :: (Monad m) => [a] -> ListT m a
-    fromList = foldr cons empty
     toList :: (Monad m) => ListT m a -> m [a]
-    toList = fmap reverse . fold (flip (:)) [] id
-    cons :: (Monad m) => a -> ListT m a -> ListT m a
-    cons x xs = ListT $ pure $ Cons x xs
+    toList = fold (flip (:)) [] reverse

--- a/automaton/src/Data/Stream.hs
+++ b/automaton/src/Data/Stream.hs
@@ -19,7 +19,10 @@ import Control.Monad.Trans.Except (ExceptT (..), except, runExceptT, throwE, wit
 import Control.Monad.Trans.Maybe (MaybeT (..))
 import Control.Monad.Trans.Reader (ReaderT (..))
 import Control.Monad.Trans.Writer (WriterT (runWriterT), writer)
-import ListT (ListT, fromFoldable, toList)
+
+-- List
+import Control.Monad.ListT (ListT)
+import Data.List.Class (fromList, toList)
 
 -- mmorph
 import Control.Monad.Morph (MFunctor (hoist))
@@ -579,4 +582,4 @@ handleMaybeT = handleEffect (MaybeT . pure) runMaybeT
 
 -- | Execute and collect all branches of a nondeterministic stream.
 handleListT :: (Monad m) => StreamT (ListT m) a -> StreamT m [a]
-handleListT = handleEffect fromFoldable toList
+handleListT = handleEffect fromList toList

--- a/automaton/src/Data/Stream.hs
+++ b/automaton/src/Data/Stream.hs
@@ -19,6 +19,7 @@ import Control.Monad.Trans.Except (ExceptT (..), except, runExceptT, throwE, wit
 import Control.Monad.Trans.Maybe (MaybeT (..))
 import Control.Monad.Trans.Reader (ReaderT (..))
 import Control.Monad.Trans.Writer (WriterT (runWriterT), writer)
+import ListT (ListT, fromFoldable, toList)
 
 -- mmorph
 import Control.Monad.Morph (MFunctor (hoist))
@@ -575,3 +576,7 @@ handleWriterT = handleEffect (writer . swap) (fmap swap . runWriterT)
 -- | Execute a stream until it stops, then output 'Nothing' forever.
 handleMaybeT :: (Monad m) => StreamT (MaybeT m) a -> StreamT m (Maybe a)
 handleMaybeT = handleEffect (MaybeT . pure) runMaybeT
+
+-- | Execute and collect all branches of a nondeterministic stream.
+handleListT :: (Monad m) => StreamT (ListT m) a -> StreamT m [a]
+handleListT = handleEffect fromFoldable toList

--- a/automaton/test/Automaton.hs
+++ b/automaton/test/Automaton.hs
@@ -32,6 +32,7 @@ import Automaton.Filter
 import Automaton.Schedule
 import Automaton.Trans.Accum
 import Automaton.Trans.Changeset
+import Automaton.Trans.List
 import Data.Automaton
 import Data.Automaton.Recursive
 import Data.Automaton.Trans.Maybe
@@ -117,6 +118,7 @@ tests =
     , Automaton.Filter.tests
     , Automaton.Trans.Accum.tests
     , Automaton.Trans.Changeset.tests
+    , Automaton.Trans.List.tests
     , Automaton.Schedule.tests
     ]
 

--- a/automaton/test/Automaton/Trans/List.hs
+++ b/automaton/test/Automaton/Trans/List.hs
@@ -10,7 +10,7 @@ import Test.Tasty.HUnit
 -- automaton
 import Control.Arrow (arr)
 import Data.Automaton (arrM, count, embed, mapS)
-import Data.Automaton.Trans.List (fromFoldable, sequenceS, widthFirst)
+import Data.Automaton.Trans.List (fromList, sequenceS, widthFirst)
 
 tests :: TestTree
 tests =
@@ -19,10 +19,10 @@ tests =
     [ testGroup
         "widthFirst"
         [ testCase "branching automaton" $
-            runIdentity (embed (widthFirst (arrM (\n -> fromFoldable [1 .. (n :: Int)]))) [2, 1])
+            runIdentity (embed (widthFirst (arrM (\n -> fromList [1 .. (n :: Int)]))) [2, 1])
               @?= [[1, 2], [1, 1]]
         , testCase "no outputs" $
-            runIdentity (embed (widthFirst (arrM $ const $ fromFoldable ([] :: [Int]))) [1, 2, 3])
+            runIdentity (embed (widthFirst (arrM $ const $ fromList ([] :: [Int]))) [1, 2, 3])
               @?= [[], [], []]
         ]
     , testGroup

--- a/automaton/test/Automaton/Trans/List.hs
+++ b/automaton/test/Automaton/Trans/List.hs
@@ -9,8 +9,8 @@ import Test.Tasty.HUnit
 
 -- automaton
 import Control.Arrow (arr)
-import Data.Automaton (arrM, count, embed)
-import Data.Automaton.Trans.List (fromFoldable, mapAutomaton, sequenceS, widthFirst)
+import Data.Automaton (arrM, count, embed, mapS)
+import Data.Automaton.Trans.List (fromFoldable, sequenceS, widthFirst)
 
 tests :: TestTree
 tests =
@@ -35,12 +35,12 @@ tests =
               @?= [[1, 1, 1], [2, 2, 2], [3, 3, 3]]
         ]
     , testGroup
-        "mapAutomaton"
+        "mapS"
         [ testCase "stateless" $
-            runIdentity (embed (mapAutomaton (arr (+ 1))) [[1, 2], [3, 4]])
+            runIdentity (embed (mapS (arr (+ 1))) [[1, 2], [3, 4]])
               @?= [[2, 3], [4, 5]]
         , testCase "stateful" $
-            runIdentity (embed (mapAutomaton count) [[(), (), ()], [(), ()]])
+            runIdentity (embed (mapS count) [[(), (), ()], [(), ()]])
               @?= [[1, 2, 3], [4, 5]]
         ]
     ]

--- a/automaton/test/Automaton/Trans/List.hs
+++ b/automaton/test/Automaton/Trans/List.hs
@@ -10,7 +10,7 @@ import Test.Tasty.HUnit
 -- automaton
 import Control.Arrow (arr)
 import Data.Automaton (arrM, count, embed, mapS)
-import Data.Automaton.Trans.List (fromList, sequenceS, widthFirst)
+import Data.Automaton.Trans.List (fromFoldable, sequenceS, widthFirst)
 
 tests :: TestTree
 tests =
@@ -19,10 +19,10 @@ tests =
     [ testGroup
         "widthFirst"
         [ testCase "branching automaton" $
-            runIdentity (embed (widthFirst (arrM (\n -> fromList [1 .. (n :: Int)]))) [2, 1])
+            runIdentity (embed (widthFirst (arrM (\n -> fromFoldable [1 .. (n :: Int)]))) [2, 1])
               @?= [[1, 2], [1, 1]]
         , testCase "no outputs" $
-            runIdentity (embed (widthFirst (arrM $ const $ fromList ([] :: [Int]))) [1, 2, 3])
+            runIdentity (embed (widthFirst (arrM $ const $ fromFoldable ([] :: [Int]))) [1, 2, 3])
               @?= [[], [], []]
         ]
     , testGroup

--- a/automaton/test/Automaton/Trans/List.hs
+++ b/automaton/test/Automaton/Trans/List.hs
@@ -1,0 +1,46 @@
+module Automaton.Trans.List where
+
+-- base
+import Control.Monad.Identity (runIdentity)
+
+-- tasty
+import Test.Tasty
+import Test.Tasty.HUnit
+
+-- automaton
+import Control.Arrow (arr)
+import Data.Automaton (arrM, count, embed)
+import Data.Automaton.Trans.List (fromFoldable, mapAutomaton, sequenceS, widthFirst)
+
+tests :: TestTree
+tests =
+  testGroup
+    "Trans.List"
+    [ testGroup
+        "widthFirst"
+        [ testCase "branching automaton" $
+            runIdentity (embed (widthFirst (arrM (\n -> fromFoldable [1 .. (n :: Int)]))) [2, 1])
+              @?= [[1, 2], [1, 1]]
+        , testCase "no outputs" $
+            runIdentity (embed (widthFirst (arrM $ const $ fromFoldable ([] :: [Int]))) [1, 2, 3])
+              @?= [[], [], []]
+        ]
+    , testGroup
+        "sequenceS"
+        [ testCase "single automaton" $
+            runIdentity (embed (widthFirst (sequenceS [arr (+ 1)])) [1, 2, 3])
+              @?= [[2], [3], [4]]
+        , testCase "multiple counters" $
+            runIdentity (embed (widthFirst (sequenceS [count, count, count])) [(), (), ()])
+              @?= [[1, 1, 1], [2, 2, 2], [3, 3, 3]]
+        ]
+    , testGroup
+        "mapAutomaton"
+        [ testCase "stateless" $
+            runIdentity (embed (mapAutomaton (arr (+ 1))) [[1, 2], [3, 4]])
+              @?= [[2, 3], [4, 5]]
+        , testCase "stateful" $
+            runIdentity (embed (mapAutomaton count) [[(), (), ()], [(), ()]])
+              @?= [[1, 2, 3], [4, 5]]
+        ]
+    ]


### PR DESCRIPTION
This uses the preexisting [list-t](https://hackage.haskell.org/package/list-t) package, instead of a [homebrew coalgebraic implementation](https://github.com/turion/rhine/pull/384).