### PR TITLE
Fix 441 performance first

### DIFF
--- a/automaton/src/Data/Automaton.hs
+++ b/automaton/src/Data/Automaton.hs
@@ -196,6 +196,7 @@ instance (Monad m) => Arrow (Automaton m) where
   {-# INLINE arr #-}
 
   first = first'
+  {-# INLINE first #-}
 
 instance (Monad m) => ArrowChoice (Automaton m) where
   Automaton (Stateful (StreamT stateL0 stepL)) +++ Automaton (Stateful (StreamT stateR0 stepR)) =

--- a/automaton/src/Data/Automaton.hs
+++ b/automaton/src/Data/Automaton.hs
@@ -292,10 +292,22 @@ constM :: (Functor m) => m b -> Automaton m a b
 constM = arrM . const
 {-# INLINE constM #-}
 
+-- | Execute the incoming effect in @m@ and return its result.
+joinS :: (Monad m) => Automaton m (m a) a
+joinS = arrM id
+{-# INLINE joinS #-}
+
 -- | Apply an arbitrary monad morphism to an automaton.
 hoistS :: (Monad m) => (forall x. m x -> n x) -> Automaton m a b -> Automaton n a b
 hoistS morph (Automaton automaton) = Automaton $ hoist (mapReaderT morph) automaton
 {-# INLINE hoistS #-}
+
+newtype MonadMorph m n = MonadMorph (forall x. m x -> n x)
+
+-- | Like 'hoistS', but the monad morphism is provided on the live input.
+hoistSS :: (Functor m, Functor n) => Automaton m a b -> Automaton n (MonadMorph m n, a) b
+hoistSS = withAutomaton $ \f (MonadMorph morph, a) -> morph $ f a
+{-# INLINE hoistSS #-}
 
 -- | Lift the monad of an automaton to a transformer.
 liftS :: (MonadTrans t, Monad m, Functor (t m)) => Automaton m a b -> Automaton (t m) a b

--- a/automaton/src/Data/Automaton.hs
+++ b/automaton/src/Data/Automaton.hs
@@ -114,6 +114,7 @@ unfold ::
   (a -> s -> Result s b) ->
   Automaton m a b
 unfold state step = unfoldM state $ fmap pure <$> step
+{-# INLINE unfold #-}
 
 -- | Create an 'Automaton' from a state and an effectful step function.
 unfoldM ::
@@ -123,6 +124,7 @@ unfoldM ::
   (a -> s -> m (Result s b)) ->
   Automaton m a b
 unfoldM state step = Automaton $! Stateful $! StreamT {state, step = \s -> ReaderT $ \a -> step a s}
+{-# INLINE unfoldM #-}
 
 -- | Like 'unfold', but output the current state.
 unfold_ ::
@@ -133,13 +135,19 @@ unfold_ ::
   (a -> s -> s) ->
   Automaton m a s
 unfold_ state step = unfold state $ \a s -> let s' = step a s in Result s' s'
+{-# INLINE unfold_ #-}
 
 instance (Eq s, Floating s, VectorSpace v s, Applicative m) => VectorSpace (Automaton m a v) (Automaton m a s) where
   zeroVector = Automaton zeroVector
+  {-# INLINE zeroVector #-}
   Automaton s *^ Automaton v = coerce $ s *^ v
+  {-# INLINE (*^) #-}
   Automaton v1 ^+^ Automaton v2 = coerce $ v1 ^+^ v2
+  {-# INLINE (^+^) #-}
   dot (Automaton s) (Automaton v) = coerce $ dot s v
+  {-# INLINE dot #-}
   normalize (Automaton v) = coerce v
+  {-# INLINE normalize #-}
 
 {- | Run both automata in parallel and use @'Semialign' m@ to decide which automaton produces output.
   If you understand @m@ as an effect that models the passage of time, then 'align' runs both automata concurrently.
@@ -151,9 +159,11 @@ instance (Semialign m) => Semialign (Automaton m a) where
         align
           (StreamOptimized.hoist' (Compose . runReaderT) $ getAutomaton automaton1)
           (StreamOptimized.hoist' (Compose . runReaderT) $ getAutomaton automaton2)
+  {-# INLINE align #-}
 
 instance (Align m) => Align (Automaton m a) where
   nil = constM nil
+  {-# INLINE nil #-}
 
 instance (Monad m) => Category (Automaton m) where
   id = Automaton $ Stateless ask
@@ -242,7 +252,9 @@ instance (Monad m) => ArrowChoice (Automaton m) where
   {-# INLINE (+++) #-}
 
   right = right'
+  {-# INLINE right #-}
   left = left'
+  {-# INLINE left #-}
 
   f ||| g = f +++ g >>> arr untag
     where
@@ -264,9 +276,11 @@ instance (MonadFix m) => ArrowLoop (Automaton m) where
 
 instance (Monad m, Alternative m) => ArrowZero (Automaton m) where
   zeroArrow = empty
+  {-# INLINE zeroArrow #-}
 
 instance (Monad m, Alternative m) => ArrowPlus (Automaton m) where
   (<+>) = (<|>)
+  {-# INLINE (<+>) #-}
 
 -- | Consume an input and produce output effectfully, without keeping internal state
 arrM :: (Functor m) => (a -> m b) -> Automaton m a b
@@ -364,6 +378,7 @@ embed (Automaton (Stateful StreamT {state, step})) = go state
       Result s' b <- runReaderT (step s) a
       (b :) <$> go s' as
 embed (Automaton (Stateless m)) = mapM $ runReaderT m
+{-# INLINE embed #-}
 
 -- * Modifying automata
 
@@ -379,8 +394,12 @@ withAutomaton_ f = Automaton . StreamOptimized.mapOptimizedStreamT (mapReaderT f
 
 instance (Functor m) => Profunctor (Automaton m) where
   dimap f g Automaton {getAutomaton} = Automaton $ g <$> StreamOptimized.hoist' (withReaderT f) getAutomaton
+  {-# INLINE dimap #-}
+
   lmap f Automaton {getAutomaton} = Automaton $ StreamOptimized.hoist' (withReaderT f) getAutomaton
+  {-# INLINE lmap #-}
   rmap = fmap
+  {-# INLINE rmap #-}
 
 instance (Applicative m) => Choice (Automaton m) where
   left' = \case
@@ -458,24 +477,29 @@ instance (Monad m) => Cochoice (Automaton m) where
         { state
         , step = \s -> ReaderT $ \a -> go s $ Left a
         }
+  {-# INLINE unleft #-}
 
 -- ** Traversing automata
 
 -- | Apply an 'Automaton' to every input.
 mapS :: (Monad m) => Automaton m a b -> Automaton m [a] [b]
 mapS = traverse'
+{-# INLINE mapS #-}
 
 -- | Only step the automaton if the input is 'Just'.
 mapMaybeS :: (Monad m) => Automaton m a b -> Automaton m (Maybe a) (Maybe b)
 mapMaybeS = traverse'
+{-# INLINE mapMaybeS #-}
 
 -- | Use an 'Automaton' with a variable amount of input.
 traverseS :: (Monad m, Traversable f) => Automaton m a b -> Automaton m (f a) (f b)
 traverseS = traverse'
+{-# INLINE traverseS #-}
 
 -- | Like 'traverseS', discarding the output.
 traverseS_ :: (Monad m, Traversable f) => Automaton m a b -> Automaton m (f a) ()
 traverseS_ automaton = traverse' automaton >>> arr (const ())
+{-# INLINE traverseS_ #-}
 
 {- | Launch arbitrarily many copies of the automaton in parallel.
 
@@ -487,6 +511,7 @@ Caution: Uses memory of the order of the largest list that was ever input during
 -}
 parallelyList :: (Applicative m) => Automaton m a b -> Automaton m [a] [b]
 parallelyList = parallely
+{-# INLINE parallelyList #-}
 
 {- | Launch many copies of the automaton in parallel, depending on the input shape.
 
@@ -509,6 +534,7 @@ Caution: Uses memory of the order of the largest input that was ever input durin
 parallely :: (Applicative m, Witherable t, Align t) => Automaton m a b -> Automaton m (t a) (t b)
 -- I'm avoiding liftS here to keep the constraint on m down to Applicative
 parallely = parallelyFinishable . handleAutomaton (StreamT.hoist' (mapReaderT (MaybeT . fmap Just)))
+{-# INLINE parallely #-}
 
 {- | Launch many copies of the automaton in parallel, depending on the input shape.
 
@@ -537,6 +563,7 @@ parallelyFinishable = \case
                 <&> (\sas -> let output = Witherable.mapMaybe snd sas in Result (Witherable.mapMaybe fst sas) output)
           }
   Automaton {getAutomaton = Stateless f} -> Automaton $ Stateless $ ReaderT $ wither $ runMaybeT <$> runReaderT f
+{-# INLINE parallelyFinishable #-}
 
 {- | Run copies of an automaton in parallel, distinguished by an index.
 
@@ -549,6 +576,7 @@ parallelyFinishable = \case
 -}
 fanIndexed :: (Applicative m, Ord i) => Automaton (MaybeT m) a b -> Automaton m (i, a) (Maybe b)
 fanIndexed automaton = dimap (\(i, a) -> (M.singleton i a, i)) (\(bs, i) -> M.lookup i bs) $ first' $ parallelyFinishable automaton
+{-# INLINE fanIndexed #-}
 
 -- ** Interaction with 'StreamT'
 
@@ -558,6 +586,7 @@ It will ignore its input.
 -}
 fromStream :: (Monad m) => StreamT m a -> Automaton m any a
 fromStream = Automaton . Stateful . hoist lift
+{-# INLINE fromStream #-}
 
 {- | Create a 'StreamT' from an 'Automaton'.
 
@@ -565,18 +594,22 @@ The resulting stream can read the current input as an effect in 'ReaderT'.
 -}
 toStreamT :: (Functor m) => Automaton m a b -> StreamT (ReaderT a m) b
 toStreamT = StreamOptimized.toStreamT . getAutomaton
+{-# INLINE toStreamT #-}
 
 -- | Given a transformation of streams, apply it to an automaton, without changing the input.
 handleAutomaton_ :: (Monad m) => (forall m. (Monad m) => StreamT m a -> StreamT m b) -> Automaton m i a -> Automaton m i b
 handleAutomaton_ f = Automaton . StreamOptimized.withOptimized f . getAutomaton
+{-# INLINE handleAutomaton_ #-}
 
 -- | Like 'handleAutomaton_', but with fewer constraints.
 handleAutomatonF_ :: (Functor m) => (forall m. (Functor m) => StreamT m a -> StreamT m b) -> Automaton m i a -> Automaton m i b
 handleAutomatonF_ f = Automaton . StreamOptimized.withOptimizedF f . getAutomaton
+{-# INLINE handleAutomatonF_ #-}
 
 -- | Given a transformation of streams, apply it to an automaton. The input can be accessed through the 'ReaderT' effect.
 handleAutomaton :: (Functor m) => (StreamT (ReaderT a m) b -> StreamT (ReaderT c n) d) -> Automaton m a b -> Automaton n c d
 handleAutomaton f = Automaton . StreamOptimized.handleOptimized f . getAutomaton
+{-# INLINE handleAutomaton #-}
 
 -- ** Buffering
 
@@ -588,6 +621,7 @@ then the next 9 inputs will be ignored.
 -}
 concatS :: (Monad m, Foldable t) => Automaton m a (t b) -> Automaton m a b
 concatS (Automaton automaton) = Automaton $ Data.Stream.Optimized.concatS automaton
+{-# INLINE concatS #-}
 
 -- * Handling effects
 
@@ -618,6 +652,7 @@ handleEffect ::
   Automaton eff a b ->
   Automaton m a (sig b)
 handleEffect send interpret = handleAutomaton $ StreamT.handleEffect (lift . send) (\raction -> ReaderT $ \a -> interpret $ runReaderT raction a)
+{-# INLINE handleEffect #-}
 
 -- | Execute and collect all branches of a nondeterministic automaton.
 handleListT :: (Monad m) => Automaton (ListT m) a b -> Automaton m a [b]
@@ -625,6 +660,7 @@ handleListT = handleEffect select toList
   where
     toList :: (Monad m) => ListT m a -> m [a]
     toList = fold (flip (:)) [] reverse
+{-# INLINE handleListT #-}
 
 -- * Examples
 
@@ -635,6 +671,7 @@ withSideEffect ::
   (a -> m b) ->
   Automaton m a a
 withSideEffect f = (id &&& arrM f) >>> arr fst
+{-# INLINE withSideEffect #-}
 
 -- | Accumulate the input, output the accumulator.
 accumulateWith ::
@@ -645,6 +682,7 @@ accumulateWith ::
   b ->
   Automaton m a b
 accumulateWith f state = unfold state $ \a b -> let b' = f a b in Result b' b'
+{-# INLINE accumulateWith #-}
 
 {- | Like 'accumulateWith', with 'mappend' as the accumulation function.
 
@@ -652,10 +690,12 @@ The new values are 'mappend'ed from the left.
 -}
 mappendFrom :: (Monoid w, Monad m) => w -> Automaton m w w
 mappendFrom = accumulateWith mappend
+{-# INLINE mappendFrom #-}
 
 -- | Like 'mappendFrom', but 'mappend'ing new values from the right.
 mappendFromR :: (Monoid w, Monad m) => w -> Automaton m w w
 mappendFromR = accumulateWith $ flip mappend
+{-# INLINE mappendFromR #-}
 
 -- | Delay the input by one step.
 delay ::
@@ -664,6 +704,7 @@ delay ::
   a ->
   Automaton m a a
 delay a0 = unfold a0 $ \aIn aState -> Result aIn aState
+{-# INLINE delay #-}
 
 {- | Delay an automaton by one step by prepending one value to the output.
 
@@ -676,18 +717,22 @@ prepend b0 automaton = proc a -> do
   case eab of
     Left b -> returnA -< b
     Right a -> automaton -< a
+{-# INLINE prepend #-}
 
 -- | Like 'mappendFrom', initialised at 'mempty'.
 mappendS :: (Monoid w, Monad m) => Automaton m w w
 mappendS = mappendFrom mempty
+{-# INLINE mappendS #-}
 
 -- | Sum up all inputs so far, with an explicit initial value.
 sumFrom :: (VectorSpace v s, Monad m) => v -> Automaton m v v
 sumFrom = accumulateWith (^+^)
+{-# INLINE sumFrom #-}
 
 -- | Like 'sumFrom', initialised at 0.
 sumS :: (Monad m, VectorSpace v s) => Automaton m v v
 sumS = sumFrom zeroVector
+{-# INLINE sumS #-}
 
 -- | Sum up all inputs so far, initialised at 0.
 sumN :: (Monad m, Num a) => Automaton m a a
@@ -709,6 +754,7 @@ initial :: (Applicative m) => Automaton m a a
 initial = unfold Nothing $ \aInput -> \case
   Nothing -> Result (Just aInput) aInput
   s@(Just a) -> Result s a
+{-# INLINE initial #-}
 
 -- | Call the monadic action once on the first tick and provide its result indefinitely.
 initialised :: (Monad m) => (a -> m b) -> Automaton m a b

--- a/automaton/src/Data/Automaton.hs
+++ b/automaton/src/Data/Automaton.hs
@@ -210,6 +210,16 @@ instance (Monad m) => Arrow (Automaton m) where
   first f = first' f
   {-# INLINE first #-}
 
+  -- Copying the default definition so I can inline it
+  f &&& g = arr (\b -> (b, b)) >>> f *** g
+  {-# INLINE (&&&) #-}
+
+  -- Copying the default definition so I can inline it
+  f *** g = first f >>> arr swap >>> first g >>> arr swap
+    where
+      swap ~(x, y) = (y, x)
+  {-# INLINE (***) #-}
+
 instance (Monad m) => ArrowChoice (Automaton m) where
   Automaton (Stateful (StreamT stateL0 stepL)) +++ Automaton (Stateful (StreamT stateR0 stepR)) =
     Automaton $!

--- a/automaton/src/Data/Automaton.hs
+++ b/automaton/src/Data/Automaton.hs
@@ -253,9 +253,9 @@ instance (Monad m) => ArrowChoice (Automaton m) where
             (runReaderT . fmap Right $ mR)
   {-# INLINE (+++) #-}
 
-  right = right'
+  right f = right' f
   {-# INLINE right #-}
-  left = left'
+  left f = left' f
   {-# INLINE left #-}
 
   f ||| g = f +++ g >>> arr untag
@@ -281,7 +281,7 @@ instance (Monad m, Alternative m) => ArrowZero (Automaton m) where
   {-# INLINE zeroArrow #-}
 
 instance (Monad m, Alternative m) => ArrowPlus (Automaton m) where
-  (<+>) = (<|>)
+  f <+> g = f <|> g
   {-# INLINE (<+>) #-}
 
 -- | Consume an input and produce output effectfully, without keeping internal state
@@ -291,7 +291,7 @@ arrM f = Automaton $! StreamOptimized.constM $! ReaderT f
 
 -- | Produce output effectfully, without keeping internal state
 constM :: (Functor m) => m b -> Automaton m a b
-constM = arrM . const
+constM mb = arrM $ const mb
 {-# INLINE constM #-}
 
 -- | Execute the incoming effect in @m@ and return its result.
@@ -703,12 +703,12 @@ accumulateWith f state = unfold state $ \a b -> let b' = f a b in Result b' b'
 The new values are 'mappend'ed from the left.
 -}
 mappendFrom :: (Monoid w, Monad m) => w -> Automaton m w w
-mappendFrom = accumulateWith mappend
+mappendFrom w = accumulateWith mappend w
 {-# INLINE mappendFrom #-}
 
 -- | Like 'mappendFrom', but 'mappend'ing new values from the right.
 mappendFromR :: (Monoid w, Monad m) => w -> Automaton m w w
-mappendFromR = accumulateWith $ flip mappend
+mappendFromR w = accumulateWith (flip mappend) w
 {-# INLINE mappendFromR #-}
 
 -- | Delay the input by one step.

--- a/automaton/src/Data/Automaton.hs
+++ b/automaton/src/Data/Automaton.hs
@@ -5,6 +5,8 @@
 {-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE UndecidableInstances #-}
 
+{- HLINT ignore "Eta reduce" -}
+
 module Data.Automaton where
 
 -- base
@@ -205,7 +207,7 @@ instance (Monad m) => Arrow (Automaton m) where
   arr f = Automaton $! Stateless $! asks f
   {-# INLINE arr #-}
 
-  first = first'
+  first f = first' f
   {-# INLINE first #-}
 
 instance (Monad m) => ArrowChoice (Automaton m) where

--- a/automaton/src/Data/Automaton.hs
+++ b/automaton/src/Data/Automaton.hs
@@ -750,7 +750,7 @@ sumS = sumFrom zeroVector
 
 -- | Sum up all inputs so far, initialised at 0.
 sumN :: (Monad m, Num a) => Automaton m a a
-sumN = arr Sum >>> mappendS >>> arr getSum
+sumN = dimap Sum getSum mappendS
 {-# INLINE sumN #-}
 
 -- | Count the natural numbers, beginning at 1.

--- a/rhine/bench/Main.hs
+++ b/rhine/bench/Main.hs
@@ -3,7 +3,8 @@ import Criterion.Main
 
 -- rhine
 import Sum
+import SumMultirate
 import WordCount
 
 main :: IO ()
-main = defaultMain [WordCount.benchmarks, Sum.benchmarks]
+main = defaultMain [WordCount.benchmarks, Sum.benchmarks, SumMultirate.benchmarks]

--- a/rhine/bench/Sum.hs
+++ b/rhine/bench/Sum.hs
@@ -4,7 +4,6 @@
 {- | Sums up natural numbers.
 
 First create a lazy list [0, 1, 2, ...] and then sum over it.
-Most of the implementations really benchmark 'embed', as the lazy list is created using it.
 -}
 module Sum where
 
@@ -14,8 +13,6 @@ import "base" Data.Void (absurd)
 
 import "criterion" Criterion.Main
 
-import "automaton" Data.Stream as Stream (StreamT (..))
-import "automaton" Data.Stream.Optimized (OptimizedStreamT (Stateful))
 import "rhine" FRP.Rhine
 
 nMax :: Int
@@ -25,17 +22,14 @@ benchmarks :: Benchmark
 benchmarks =
   bgroup
     "Sum"
-    [ bench "rhine" $ nf rhine nMax
-    , bench "rhine flow" $ nf rhineFlow nMax
-    , bench "automaton" $ nf automaton nMax
+    [ bench "rhine flow" $ nf rhineFlow nMax
+    , bench "rhine IO" $ whnfIO rhineIO
+    , bench "automaton reactimate" $ nf automatonReactimate nMax
+    , bench "automaton reactimate IO" $ whnfIO automatonReactimateIO
     , bench "direct" $ nf direct nMax
     , bench "direct monad" $ nf directM nMax
     ]
 
-rhine :: Int -> Int
-rhine n = sum $ runIdentity $ embed count $ replicate n ()
-
--- FIXME separate ticket to improve performance of this
 rhineFlow :: Int -> Int
 rhineFlow n =
   either id absurd $
@@ -47,17 +41,37 @@ rhineFlow n =
           then returnA -< ()
           else arrMCl Left -< s
 
-automaton :: Int -> Int
-automaton n = sum $ runIdentity $ embed myCount $ replicate n ()
-  where
-    myCount :: Automaton Identity () Int
-    myCount =
-      Automaton $
-        Stateful
-          StreamT
-            { state = 1
-            , Stream.step = \s -> return $! Result (s + 1) s
-            }
+rhineIO :: IO Int
+rhineIO = fmap (either id absurd) $
+  runExceptT $
+    flow $
+      (@@ Trivial) $ proc () -> do
+        k <- count -< ()
+        s <- sumN -< k
+        if k < nMax
+          then returnA -< ()
+          else throwS -< s
+
+automatonReactimate :: Int -> Int
+automatonReactimate n =
+  either id absurd $
+    reactimate $ proc () -> do
+      k <- count -< ()
+      s <- sumN -< k
+      if k < n
+        then returnA -< ()
+        else arrM Left -< s
+
+automatonReactimateIO :: IO Int
+automatonReactimateIO = fmap (either id absurd) $
+  runExceptT $
+    reactimate $
+      proc () -> do
+        k <- count -< ()
+        s <- sumN -< k
+        if k < nMax
+          then returnA -< ()
+          else arrM throwE -< s
 
 direct :: Int -> Int
 direct n = sum [0 .. n]

--- a/rhine/bench/SumMultirate.hs
+++ b/rhine/bench/SumMultirate.hs
@@ -1,0 +1,69 @@
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE PackageImports #-}
+
+{- | Sums up natural numbers.
+
+First create a lazy list [0, 1, 2, ...] and then sum over it.
+-}
+module SumMultirate where
+
+import "base" Data.Void (absurd)
+
+import "criterion" Criterion.Main
+
+import "rhine" FRP.Rhine
+
+nMax :: Int
+-- nMax = 1_000_000
+nMax = 100_000 -- Multirate is much slower, so we reduce the number of iterations to get a result in a reasonable time
+
+benchmarks :: Benchmark
+benchmarks =
+  bgroup
+    "Sum Multirate"
+    [ bench "rhine flow" $ whnfIO $ rhineFlow nMax
+    , bench "rhine single threaded" $ whnf rhineSingleThreaded nMax
+    , bench "automaton reactimate" $ whnfIO $ automatonReactimate nMax
+    , bench "direct" $ nf direct nMax
+    ]
+
+rhineFlow :: Int -> IO Int
+rhineFlow n =
+  fmap (either id absurd) $
+    runExceptT $
+      flow $
+        (count @@ Busy) >-- collect --> traverseS consumer >-> arr (const ()) @@ waitClock @1
+  where
+    consumer = proc k -> do
+      s <- sumN -< k
+      if k < n
+        then returnA -< ()
+        else arrMCl throwE -< s
+
+rhineSingleThreaded :: Int -> Int
+rhineSingleThreaded n =
+  either id absurd $
+    flow $
+      (@@ Trivial) $ proc () -> do
+        k <- count -< ()
+        s <- sumN -< k
+        if k < n
+          then returnA -< ()
+          else arrMCl Left -< s
+
+-- This is a single threaded comparison, so expected to be faster
+automatonReactimate :: Int -> IO Int
+automatonReactimate n =
+  fmap (either id absurd) $
+    runExceptT $
+      reactimate $ proc () -> do
+        k <- count -< ()
+        s <- sumN -< k
+        if k < n
+          then returnA -< ()
+          else arrM throwE -< s
+
+-- There is no good direct comparison since we can't model the scheduling well
+-- So I'll just wastefully create a list of list and concatenate it again... maybe it hits some performance
+direct :: Int -> Int
+direct n = sum $ concatMap pure [0 .. n]

--- a/rhine/bench/Test.hs
+++ b/rhine/bench/Test.hs
@@ -27,5 +27,7 @@ main =
           [ testCase "rhine" $ Sum.rhine Sum.nMax @?= Sum.direct Sum.nMax
           , testCase "automaton" $ Sum.automaton Sum.nMax @?= Sum.direct Sum.nMax
           , testCase "rhine flow" $ Sum.rhineFlow Sum.nMax @?= Sum.direct Sum.nMax
+          , testCase "rhine IO" $ Sum.rhineIO >>= (@?= Sum.direct Sum.nMax)
+          , testCase "automaton reactimate" $ Sum.automatonReactimate >>= (@?= Sum.direct Sum.nMax)
           ]
       ]

--- a/rhine/bench/Test.hs
+++ b/rhine/bench/Test.hs
@@ -24,10 +24,9 @@ main =
           ]
       , testGroup
           "Sum"
-          [ testCase "rhine" $ Sum.rhine Sum.nMax @?= Sum.direct Sum.nMax
-          , testCase "automaton" $ Sum.automaton Sum.nMax @?= Sum.direct Sum.nMax
-          , testCase "rhine flow" $ Sum.rhineFlow Sum.nMax @?= Sum.direct Sum.nMax
+          [ testCase "rhine flow" $ Sum.rhineFlow Sum.nMax @?= Sum.direct Sum.nMax
           , testCase "rhine IO" $ Sum.rhineIO >>= (@?= Sum.direct Sum.nMax)
-          , testCase "automaton reactimate" $ Sum.automatonReactimate >>= (@?= Sum.direct Sum.nMax)
+          , testCase "automaton reactimate" $ Sum.automatonReactimate Sum.nMax @?= Sum.direct Sum.nMax
+          , testCase "automaton reactimate IO" $ Sum.automatonReactimateIO >>= (@?= Sum.direct Sum.nMax)
           ]
       ]

--- a/rhine/bench/WordCount.hs
+++ b/rhine/bench/WordCount.hs
@@ -70,7 +70,7 @@ withInput action = do
 rhineWordCount :: IO Int
 rhineWordCount = do
   Left (Right nWords) <- withInput $ runExceptT $ flow $ wc @@ delayIOError (ExceptClock StdinClock) Left
-  return nWords
+  pure nWords
   where
     wc :: ClSF (ExceptT (Either IOError Int) IO) (DelayIOError (ExceptClock StdinClock IOError) (Either IOError Int)) () ()
     wc = proc _ -> do
@@ -86,7 +86,7 @@ if all the extra complexity introduced by clocks is optimized away completely.
 automatonWordCount :: IO Int
 automatonWordCount = do
   Left (Right nWords) <- withInput $ runExceptT $ reactimate wc
-  return nWords
+  pure nWords
   where
     wc = proc () -> do
       lineOrEOF <- constM $ liftIO $ Control.Exception.try getLine -< ()
@@ -109,7 +109,7 @@ textWordCount = do
   wcOut <- newIORef (0 :: Int)
   catch (withInput $ go wcOut) $ \(e :: IOError) ->
     if isEOFError e
-      then return ()
+      then pure ()
       else throwIO e
   readIORef wcOut
   where
@@ -129,14 +129,14 @@ textWordCountNoIORef = do
   where
     processLine n = do
       line <- getLine
-      return $ Right $ n + length (words line)
+      pure $ Right $ n + length (words line)
     go n = do
       n' <- catch (processLine n) $
         \(e :: IOError) ->
           if isEOFError e
-            then return $ Left n
+            then pure $ Left n
             else throwIO e
-      either return go n'
+      either pure go n'
 
 -- | Just for fun the probably most readable but not the fastest way to count the number of words.
 textLazy :: IO Int

--- a/rhine/rhine.cabal
+++ b/rhine/rhine.cabal
@@ -192,6 +192,7 @@ benchmark benchmark
   other-modules:
     Paths_rhine
     Sum
+    SumMultirate
     WordCount
 
   build-depends:

--- a/rhine/src/FRP/Rhine/ClSF/Util.hs
+++ b/rhine/src/FRP/Rhine/ClSF/Util.hs
@@ -123,6 +123,7 @@ infixr 6 >->
   cat b c ->
   cat a c
 (>->) = (>>>)
+{-# INLINE (>->) #-}
 
 -- | Alias for 'Control.Category.<<<'.
 infixl 6 <-<

--- a/rhine/src/FRP/Rhine/ClSF/Util.hs
+++ b/rhine/src/FRP/Rhine/ClSF/Util.hs
@@ -400,7 +400,7 @@ delayBy ::
   -- | The time span to delay the signal
   Diff td ->
   BehaviorF m td a a
-delayBy dTime = historySince dTime >>> arr (viewr >>> safeHead) >>> lastS undefined >>> arr snd
+delayBy dTime = historySince dTime >>> arr (viewr >>> safeHead) >>> lastS (error "not implemented") >>> arr snd
   where
     safeHead EmptyR = Nothing
     safeHead (_ :> a) = Just a

--- a/rhine/src/FRP/Rhine/Clock/Realtime/Millisecond.hs
+++ b/rhine/src/FRP/Rhine/Clock/Realtime/Millisecond.hs
@@ -10,22 +10,23 @@ module FRP.Rhine.Clock.Realtime.Millisecond where
 
 -- base
 import Control.Arrow (arr, first, second, (>>>))
+import Control.Monad.IO.Class (MonadIO (..))
+import Data.Functor ((<&>))
+import GHC.TypeLits
 
 -- time
-
--- rhine
-
-import Data.Automaton (count)
-import Data.Functor ((<&>))
 import Data.Time.Clock
 
--- rhine
+-- automaton
+import Data.Automaton (count, hoistS)
 
+-- time-domain
 import Data.TimeDomain (Seconds (..))
+
+-- rhine
 import FRP.Rhine.Clock
 import FRP.Rhine.Clock.Proxy
 import FRP.Rhine.Clock.Realtime (WaitUTCClock, waitUTC)
-import GHC.TypeLits
 
 {- | A clock ticking every 'n' milliseconds, in real time.
 
@@ -41,10 +42,10 @@ and @'Just' lag@ a lag (in seconds).
 -}
 newtype Millisecond (n :: Nat) = Millisecond (WaitUTCClock IO (RescaledClock (CountClock n) (Seconds Double)))
 
-instance (KnownNat n) => Clock IO (Millisecond n) where
+instance (KnownNat n, MonadIO m) => Clock m (Millisecond n) where
   type Time (Millisecond n) = UTCTime
   type Tag (Millisecond n) = Maybe Double
-  initClock (Millisecond cl) = initClock cl <&> first (>>> arr (second (fmap getSeconds . snd)))
+  initClock (Millisecond cl) = liftIO (initClock cl) <&> first ((>>> arr (second (fmap getSeconds . snd))) . hoistS liftIO)
   {-# INLINE initClock #-}
 
 instance GetClockProxy (Millisecond n)

--- a/rhine/src/FRP/Rhine/Reactimation/Combinators.hs
+++ b/rhine/src/FRP/Rhine/Reactimation/Combinators.hs
@@ -64,6 +64,7 @@ data RhineAndResamplingBuffer m cl1 inCl2 a c
   ResamplingBuffer         m (Out cl1) inCl2   b c ->
   RhineAndResamplingBuffer m      cl1  inCl2 a   c
 (>--) = RhineAndResamplingBuffer
+{-# INLINE (>--) #-}
 
 {- | The combinators for sequential composition allow for the following syntax:
 
@@ -99,6 +100,7 @@ infixr 1 -->
   Rhine m (SequentialClock cl1 cl2) a c
 RhineAndResamplingBuffer (Rhine sn1 cl1) rb --> (Rhine sn2 cl2) =
   Rhine (sequential sn1 rb sn2) (SequentialClock cl1 cl2)
+{-# INLINE (-->) #-}
 
 {- | The combinators for parallel composition allow for the following syntax:
 

--- a/rhine/src/FRP/Rhine/ResamplingBuffer/Collect.hs
+++ b/rhine/src/FRP/Rhine/ResamplingBuffer/Collect.hs
@@ -25,6 +25,7 @@ collect = timelessResamplingBuffer AsyncMealy {..} []
   where
     amPut as a = pure $ a : as
     amGet as = pure $! Result [] as
+{-# INLINE collect #-}
 
 {- | Reimplementation of 'collect' with sequences,
    which gives a performance benefit if the sequence needs to be reversed or searched.

--- a/rhine/src/FRP/Rhine/ResamplingBuffer/Collect.hs
+++ b/rhine/src/FRP/Rhine/ResamplingBuffer/Collect.hs
@@ -23,8 +23,8 @@ import FRP.Rhine.ResamplingBuffer.Timeless
 collect :: (Monad m) => ResamplingBuffer m cl1 cl2 a [a]
 collect = timelessResamplingBuffer AsyncMealy {..} []
   where
-    amPut as a = return $ a : as
-    amGet as = return $! Result [] as
+    amPut as a = pure $ a : as
+    amGet as = pure $! Result [] as
 
 {- | Reimplementation of 'collect' with sequences,
    which gives a performance benefit if the sequence needs to be reversed or searched.
@@ -32,8 +32,8 @@ collect = timelessResamplingBuffer AsyncMealy {..} []
 collectSequence :: (Monad m) => ResamplingBuffer m cl1 cl2 a (Seq a)
 collectSequence = timelessResamplingBuffer AsyncMealy {..} empty
   where
-    amPut as a = return $ a <| as
-    amGet as = return $! Result empty as
+    amPut as a = pure $ a <| as
+    amGet as = pure $! Result empty as
 
 {- | 'pureBuffer' collects all input values lazily in a list
    and processes it when output is required.
@@ -43,8 +43,8 @@ collectSequence = timelessResamplingBuffer AsyncMealy {..} empty
 pureBuffer :: (Monad m) => ([a] -> b) -> ResamplingBuffer m cl1 cl2 a b
 pureBuffer f = timelessResamplingBuffer AsyncMealy {..} []
   where
-    amPut as a = return (a : as)
-    amGet as = return $! Result [] $! f as
+    amPut as a = pure (a : as)
+    amGet as = pure $! Result [] $! f as
 
 -- TODO Test whether strictness works here, or consider using deepSeq
 
@@ -60,5 +60,5 @@ foldBuffer ::
   ResamplingBuffer m cl1 cl2 a b
 foldBuffer f = timelessResamplingBuffer AsyncMealy {..}
   where
-    amPut b a = let !b' = f a b in return b'
-    amGet b = return $! Result b b
+    amPut b a = let !b' = f a b in pure b'
+    amGet b = pure $! Result b b

--- a/rhine/src/FRP/Rhine/ResamplingBuffer/Timeless.hs
+++ b/rhine/src/FRP/Rhine/ResamplingBuffer/Timeless.hs
@@ -49,7 +49,7 @@ trivialResamplingBuffer :: (Monad m) => ResamplingBuffer m cl1 cl2 () ()
 trivialResamplingBuffer =
   timelessResamplingBuffer
     AsyncMealy
-      { amPut = const (const (return ()))
-      , amGet = const (return $! Result () ())
+      { amPut = const (const (pure ()))
+      , amGet = const (pure $! Result () ())
       }
     ()

--- a/rhine/src/FRP/Rhine/ResamplingBuffer/Timeless.hs
+++ b/rhine/src/FRP/Rhine/ResamplingBuffer/Timeless.hs
@@ -43,6 +43,7 @@ timelessResamplingBuffer AsyncMealy {..} buffer = ResamplingBuffer {..}
   where
     put _ a s = amPut s a
     get _ = amGet
+{-# INLINE timelessResamplingBuffer #-}
 
 -- | A resampling buffer that only accepts and emits units.
 trivialResamplingBuffer :: (Monad m) => ResamplingBuffer m cl1 cl2 () ()


### PR DESCRIPTION
Running `cabal bench benchmark --benchmark-options="-m pattern flow"` shows that the performance on the sum rhine flow benchmark improves by >100x.