### PR TITLE
Allow QuickCheck 2.16

### DIFF
--- a/automaton/automaton.cabal
+++ b/automaton/automaton.cabal
@@ -127,7 +127,7 @@ test-suite automaton-test
     Stream
 
   build-depends:
-    QuickCheck >=2.14 && <2.16,
+    QuickCheck >=2.14 && <2.17,
     automaton,
     tasty >=1.4 && <1.6,
     tasty-hunit ^>=0.10,

--- a/monad-schedule/monad-schedule.cabal
+++ b/monad-schedule/monad-schedule.cabal
@@ -62,7 +62,7 @@ test-suite test
   hs-source-dirs: test
   build-depends:
     HUnit ^>=1.6,
-    QuickCheck >=2.14 && <2.16,
+    QuickCheck >=2.14 && <2.17,
     generic-arbitrary ^>=1.0,
     monad-schedule,
     test-framework ^>=0.8,

--- a/rhine/rhine.cabal
+++ b/rhine/rhine.cabal
@@ -82,7 +82,7 @@ common opts
 
 common test-deps
   build-depends:
-    QuickCheck >=2.14 && <2.16,
+    QuickCheck >=2.14 && <2.17,
     tasty >=1.4 && <1.6,
     tasty-hunit ^>=0.10,
     tasty-quickcheck >=0.10 && <1.12,


### PR DESCRIPTION
The test suites of `automaton`, `monad-schedule` and `rhine` pinned `QuickCheck >=2.14 && <2.16`. Stackage Nightly now ships **QuickCheck 2.16.0.0**, so these packages fail to configure (`Encountered missing or private dependencies: QuickCheck >=2.14 && <2.16`).

This surfaced while fixing the maintained Haskell packages on nixpkgs `haskell-updates` ([NixOS/nixpkgs#521260](https://github.com/NixOS/nixpkgs/pull/521260)). The `<2.16` upper bound also kept CI from ever resolving 2.16, so any incompatibility was hidden — CI here will now actually exercise QuickCheck 2.16.

Bumps the upper bound to `<2.17` in the three affected `.cabal` files.